### PR TITLE
update cloudprovider.Create method to wait for provider id

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -418,10 +418,15 @@ func (c *CloudProvider) pollForUnclaimedMachineInMachineDeploymentWithTimeout(ct
 			return false, nil
 		}
 
-		// take the first Machine from the list
-		machine = machineList[0]
+		// find the first machine with a provider id
+		for i, m := range machineList {
+			if m.Spec.ProviderID != nil {
+				machine = machineList[i]
+				return true, nil
+			}
+		}
 
-		return true, nil
+		return false, nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error polling for an unclaimed Machine in MachineDeployment %q: %w", machineDeployment.Name, err)


### PR DESCRIPTION
this change adds an extra clause to the polling function for machines in a machinedeployment so that the function will wait until a machine with a provider id is available.

it is possible on some infrastructures, for a machine to be returned with no provider id. when this happens, the infrastructure will asynchronously add the provider id later.

i was talking with Jim Kong on kubernetes slack, and he is encountering an issue where a machine is created without the provider id, then it is added later. when this happens the controller will panic with a nil dereference.

this patch is a temporary fix that will allow the controller to ensure that a machine with a provider id is returned. it will may the create method take more time and this the controller will have to block for longer periods. this should only be an issue under heavy scaling though.