### PR TITLE
add Nodeclass controller

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	clusterapi "sigs.k8s.io/karpenter-provider-cluster-api/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/controllers"
 	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/operator"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
-	"sigs.k8s.io/karpenter/pkg/controllers"
+	corecontrollers "sigs.k8s.io/karpenter/pkg/controllers"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	coreoperator "sigs.k8s.io/karpenter/pkg/operator"
 )
@@ -32,7 +33,7 @@ func main() {
 	cloudProvider := metrics.Decorate(capiCloudProvider)
 	clusterState := state.NewCluster(op.Clock, op.GetClient(), cloudProvider)
 	op.
-		WithControllers(ctx, controllers.NewControllers(
+		WithControllers(ctx, corecontrollers.NewControllers(
 			ctx,
 			op.Manager,
 			op.Clock,
@@ -40,5 +41,13 @@ func main() {
 			op.EventRecorder,
 			cloudProvider,
 			clusterState,
+		)...).
+		WithControllers(ctx, controllers.NewControllers(
+			ctx,
+			op.Manager,
+			op.Clock,
+			op.GetClient(),
+			op.EventRecorder,
+			cloudProvider,
 		)...).Start(ctx)
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 )
 
 require (
+	github.com/Pallinder/go-randomdata v1.2.0 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -42,6 +44,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/awslabs/operatorpkg/controller"
+
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	statuscontroller "sigs.k8s.io/karpenter-provider-cluster-api/pkg/controllers/nodeclass/status"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/events"
+)
+
+func NewControllers(
+	ctx context.Context,
+	mgr manager.Manager,
+	clock clock.Clock,
+	kubeClient client.Client,
+	recorder events.Recorder,
+	cloudProvider cloudprovider.CloudProvider,
+) []controller.Controller {
+	controllers := []controller.Controller{
+		statuscontroller.NewController(kubeClient),
+	}
+	return controllers
+}

--- a/pkg/controllers/nodeclass/status/controller.go
+++ b/pkg/controllers/nodeclass/status/controller.go
@@ -41,8 +41,12 @@ func NewController(kubeClient client.Client) *Controller {
 	}
 }
 
+func (c *Controller) Name() string {
+	return "nodeclass.status"
+}
+
 func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1alpha1.ClusterAPINodeClass) (reconcile.Result, error) {
-	ctx = injection.WithControllerName(ctx, "nodeclass.status")
+	ctx = injection.WithControllerName(ctx, c.Name())
 	stored := nodeClass.DeepCopy()
 
 	// for now, we just want to set all nodeclasses to ready. in the future we may want
@@ -68,7 +72,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1alpha1.ClusterA
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 	b := controllerruntime.NewControllerManagedBy(m).
-		Named("nodeclass.status").
+		Named(c.Name()).
 		For(&v1alpha1.ClusterAPINodeClass{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10})
 

--- a/pkg/controllers/nodeclass/status/controller.go
+++ b/pkg/controllers/nodeclass/status/controller.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+
+	"github.com/awslabs/operatorpkg/status"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/apis/v1alpha1"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+)
+
+type Controller struct {
+	kubeClient client.Client
+}
+
+func NewController(kubeClient client.Client) *Controller {
+	return &Controller{
+		kubeClient: kubeClient,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1alpha1.ClusterAPINodeClass) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, "nodeclass.status")
+	stored := nodeClass.DeepCopy()
+
+	// for now, we just want to set all nodeclasses to ready. in the future we may want
+	// to add other types of checks to ensure that the underlying cluster-api objects are
+	// also ready.
+	ready := nodeClass.StatusConditions().Get(status.ConditionReady)
+	if ready.IsUnknown() || ready.IsFalse() {
+		nodeClass.StatusConditions().SetTrue(status.ConditionReady)
+	}
+
+	if !equality.Semantic.DeepEqual(stored, nodeClass) {
+		// this code is inspired by karpenter/pkg/controllers/nodepool/readiness controller
+		if err := c.kubeClient.Status().Patch(ctx, nodeClass, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
+			if errors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	b := controllerruntime.NewControllerManagedBy(m).
+		Named("nodeclass.status").
+		For(&v1alpha1.ClusterAPINodeClass{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10})
+
+	return b.Complete(reconcile.AsReconciler(m.GetClient(), c))
+}

--- a/pkg/controllers/nodeclass/status/controller_test.go
+++ b/pkg/controllers/nodeclass/status/controller_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	awsstatus "github.com/awslabs/operatorpkg/status"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/apis/v1alpha1"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+var _ = Describe("NodeClass Status Controller", func() {
+	AfterEach(func() {
+		test.EventuallyDeleteAllOf(cl, &v1alpha1.ClusterAPINodeClass{}, &v1alpha1.ClusterAPINodeClassList{}, testNamespace)
+	})
+
+	It("adds the ready condition to a new NodeClass", func() {
+		nodeClass := &v1alpha1.ClusterAPINodeClass{}
+		nodeClass.Name = "default"
+		ExpectApplied(ctx, cl, nodeClass)
+		ExpectObjectReconciled(ctx, cl, controller, nodeClass)
+		nodeClass = ExpectExists(ctx, cl, nodeClass)
+
+		Expect(nodeClass.StatusConditions().IsTrue(awsstatus.ConditionReady)).To(BeTrue())
+	})
+})

--- a/pkg/controllers/nodeclass/status/suite_test.go
+++ b/pkg/controllers/nodeclass/status/suite_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2/textlogger"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/apis/v1alpha1"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/controllers/nodeclass/status"
+)
+
+const (
+	testNamespace = "karpenter-cluster-api"
+)
+
+var ctx context.Context
+var cfg *rest.Config
+var cl client.Client
+var testEnv *envtest.Environment
+var testScheme *runtime.Scheme
+var controller *status.Controller
+
+func TestMachineProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "NodeClass.Status Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	logf.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "apis", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	ctx = context.Background()
+
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	testScheme = scheme.Scheme
+	Expect(capiv1beta1.AddToScheme(testScheme)).To(Succeed())
+	Expect(v1alpha1.AddToScheme(testScheme)).To(Succeed())
+
+	cl, err = client.New(cfg, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cl).NotTo(BeNil())
+
+	namespace := &corev1.Namespace{}
+	namespace.SetName(testNamespace)
+	Expect(cl.Create(context.Background(), namespace)).To(Succeed())
+
+	controller = status.NewController(cl)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func EventuallyDeleteAllOf(cl client.Client, obj client.Object, ls client.ObjectList, namespace string) {
+	Expect(cl.DeleteAllOf(context.Background(), obj, client.InNamespace(namespace))).To(Succeed())
+	Eventually(func() client.ObjectList {
+		Expect(cl.List(context.Background(), ls, client.InNamespace(namespace))).To(Succeed())
+		return ls
+	}).Should(HaveField("Items", HaveLen(0)))
+}


### PR DESCRIPTION
this change adds a basic nodeclass controller. it is being proposed because the core karpenter will not mark nodepools as ready until their nodeclass is ready.

the controller is very basic and will set any ClusterAPINodeClass to ready. there is also a simple test to exercise the behavior. the intention is to build on these primitives for followup improvements.

fixes #22 