### PR TITLE
add not found errors to Get and Delete

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -174,7 +174,7 @@ func (c *CloudProvider) Delete(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 		return fmt.Errorf("error finding Machine with provider ID %q to Delete NodeClaim %q: %w", nodeClaim.Status.ProviderID, nodeClaim.Name, err)
 	}
 	if machine == nil {
-		return fmt.Errorf("unable to find Machine with provider ID %q to Delete NodeClaim %q", nodeClaim.Status.ProviderID, nodeClaim.Name)
+		return cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("unable to find Machine with provider ID %q to Delete NodeClaim %q", nodeClaim.Status.ProviderID, nodeClaim.Name))
 	}
 
 	// check if already deleting
@@ -227,10 +227,10 @@ func (c *CloudProvider) Get(ctx context.Context, providerID string) (*karpv1.Nod
 
 	machine, err := c.machineProvider.Get(ctx, providerID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find Machine for Get: %w", err)
+		return nil, fmt.Errorf("error getting Machine: %w", err)
 	}
 	if machine == nil {
-		return nil, nil
+		return nil, cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("cannot find Machine with provider ID %q", providerID))
 	}
 
 	nodeClaim, err := c.machineToNodeClaim(ctx, machine)

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -226,9 +226,9 @@ var _ = Describe("CloudProvider.Get method", func() {
 		Expect(nodeClaim).To(BeNil())
 	})
 
-	It("returns nil when the Machine is not present", func() {
+	It("returns error when the Machine is not present", func() {
 		nodeClaim, err := provider.Get(context.Background(), "clusterapi://the-wrong-provider-id")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(MatchError(fmt.Errorf("cannot find Machine with provider ID %q", "clusterapi://the-wrong-provider-id")))
 		Expect(nodeClaim).To(BeNil())
 	})
 


### PR DESCRIPTION
this change updates the returns to use the core cloudprovider NodeClaimNotFoundError when the instance cannot be found.