### PR TITLE
Add Dockerfile and makefile rule for image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILDER_IMAGE
+ARG ARCH
+
+FROM ${BUILDER_IMAGE} AS builder
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy the sources
+COPY ./ ./
+
+# Cache the go build into the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+    go build -trimpath -o manager cmd/controller/main.go
+
+# Production image
+FROM gcr.io/distroless/static:nonroot-${ARCH}
+WORKDIR /
+COPY --from=builder /workspace/manager .
+# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
+USER 65532
+ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ GINKGO_ARGS = -v --randomize-all --randomize-suites --keep-going --race --trace 
 
 CONTROLLER_GEN = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 
+ARCH ?= $(shell go env GOARCH)
+
+CONTAINER_RUNTIME ?= docker
+BUILDER_IMAGE ?= docker.io/library/golang:1.24.2
+IMG ?= karpenter-clusterapi-controller
+
 all: help
 
 .PHONY: build
@@ -41,6 +47,10 @@ generate: gen-objects manifests ## generate all controller-gen files
 
 karpenter-clusterapi-controller: ## build the main karpenter controller
 	go build -o bin/karpenter-clusterapi-controller cmd/controller/main.go
+
+.PHONY: image
+image: ## Build manager container image
+	$(CONTAINER_RUNTIME) build --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg ARCH=$(ARCH) . -t $(IMG)
 
 .PHONY: manifests
 manifests: ## generate the controller-gen kubernetes manifests


### PR DESCRIPTION
Adds a Dockerfile to containerize the application and a new `image` rule to the Makefile for building the image. This streamlines the build process and makes it easier to deploy