### PR TITLE
Move BUILDER_IMAGE default from Makefile to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ARG BUILDER_IMAGE
 ARG ARCH
 
-FROM ${BUILDER_IMAGE} AS builder
+FROM ${BUILDER_IMAGE:-docker.io/library/golang:1.24.2} AS builder
 WORKDIR /workspace
 
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CONTROLLER_GEN = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-tools/cmd/c
 ARCH ?= $(shell go env GOARCH)
 
 CONTAINER_RUNTIME ?= docker
-BUILDER_IMAGE ?= docker.io/library/golang:1.24.2
+BUILDER_IMAGE ?=
 IMG ?= karpenter-clusterapi-controller
 
 all: help


### PR DESCRIPTION
This commit is to avoid build-time warnings when `BUILDER_IMAGE` default in Dockerfile is unset during docker build.

The following warning is shown when running `make image`:
```
=> WARN: InvalidDefaultArgInFrom: Default value for ARG ${BUILDER_IMAGE} results in empty or invalid base image name (line 18)                                                                                                                                                                                         0.0s
```

This change ensures a cleaner build process and avoids confusion for users who rely on the default Dockerfile configuration.