### PR TITLE
Rename binary in container to 'karpenter-clusterapi-controller'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,12 @@ COPY ./ ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -trimpath -o manager cmd/controller/main.go
+    go build -trimpath -o karpenter-clusterapi-controller cmd/controller/main.go
 
 # Production image
 FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/karpenter-clusterapi-controller .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 USER 65532
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/karpenter-clusterapi-controller"]

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           image: {{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /manager
+            - /karpenter-clusterapi-controller
           {{- with .Values.arguments }}
           args:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
This PR renames the binary inside the container image from `manager` to `karpenter-clusterapi-controller` to match the output name produced by `make build`.

Changes include:
- Dockerfile: updated `go build` output, `COPY`, and `ENTRYPOINT` to use the new binary name
- Helm chart (`deployment.yaml`): updated the `command` field to launch the renamed binary

This improves consistency between the build process.