### PR TITLE
docs: Add settings.md and script for auto-generating this doc

### DIFF
--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -1,0 +1,30 @@
+# Settings
+
+[comment]: <> (the content below is generated from hack/docs/settings_gen/main.go)
+
+Karpenter exposes environment variables and CLI flags that allow you to configure controller behavior. The available settings are outlined below.
+
+| Environment Variable | CLI Flag | Description |
+|--|--|--|
+| BATCH_IDLE_DURATION | \-\-batch-idle-duration | The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately. (default = 1s)|
+| BATCH_MAX_DURATION | \-\-batch-max-duration | The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes. (default = 10s)|
+| CLUSTER_API_CERTIFICATE_AUTHORITY_DATA | \-\-cluster-api-certificate-authority-data | The cert certificate authority of the cluster api manager cluster|
+| CLUSTER_API_KUBECONFIG | \-\-cluster-api-kubeconfig | The path to the cluster api manager cluster kubeconfig file.  Defaults to service account credentials if not specified.|
+| CLUSTER_API_SKIP_TLS_VERIFY | \-\-cluster-api-skip-tls-verify | Skip the check for certificate for validity of the cluster api manager cluster. This will make HTTPS connections insecure|
+| CLUSTER_API_TOKEN | \-\-cluster-api-token | The Bearer token for authentication of the cluster api manager cluster|
+| CLUSTER_API_URL | \-\-cluster-api-url | The url of the cluster api manager cluster|
+| DISABLE_LEADER_ELECTION | \-\-disable-leader-election | Disable the leader election client before executing the main loop. Disable when running replicated components for high availability is not desired.|
+| ENABLE_PROFILING | \-\-enable-profiling | Enable the profiling on the metric endpoint|
+| FEATURE_GATES | \-\-feature-gates | Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, and SpotToSpotConsolidation (default = NodeRepair=false,ReservedCapacity=false,SpotToSpotConsolidation=false)|
+| HEALTH_PROBE_PORT | \-\-health-probe-port | The port the health probe endpoint binds to for reporting controller health (default = 8081)|
+| KARPENTER_SERVICE | \-\-karpenter-service | The Karpenter Service name for the dynamic webhook certificate|
+| KUBE_CLIENT_BURST | \-\-kube-client-burst | The maximum allowed burst of queries to the kube-apiserver (default = 300)|
+| KUBE_CLIENT_QPS | \-\-kube-client-qps | The smoothed rate of qps to kube-apiserver (default = 200)|
+| LEADER_ELECTION_NAME | \-\-leader-election-name | Leader election name to create and monitor the lease if running outside the cluster (default = karpenter-leader-election)|
+| LEADER_ELECTION_NAMESPACE | \-\-leader-election-namespace | Leader election namespace to create and monitor the lease if running outside the cluster|
+| LOG_ERROR_OUTPUT_PATHS | \-\-log-error-output-paths | Optional comma separated paths for logging error output (default = stderr)|
+| LOG_LEVEL | \-\-log-level | Log verbosity level. Can be one of 'debug', 'info', or 'error' (default = info)|
+| LOG_OUTPUT_PATHS | \-\-log-output-paths | Optional comma separated paths for directing log output (default = stdout)|
+| MEMORY_LIMIT | \-\-memory-limit | Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value. (default = -1)|
+| METRICS_PORT | \-\-metrics-port | The port the metric endpoint binds to for operating metrics about the controller itself (default = 8080)|
+| PREFERENCE_POLICY | \-\-preference-policy | How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect' (default = Respect)|

--- a/hack/docs/settings_gen/main.go
+++ b/hack/docs/settings_gen/main.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/operator/options"
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatalf("Usage: go run main.go <path/to/settings.md>")
+	}
+	outputFileName := os.Args[1]
+
+	title := "# Settings\n\n"
+	comment := "[comment]: <> (the content below is generated from hack/docs/settings_gen/main.go)\n\n"
+	description := "Karpenter exposes environment variables and CLI flags that allow you to configure controller behavior. The available settings are outlined below.\n\n"
+
+	fs := &coreoptions.FlagSet{
+		FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+	}
+	(&coreoptions.Options{}).AddFlags(fs)
+	(&options.Options{}).AddFlags(fs)
+
+	envVarsTable := "| Environment Variable | CLI Flag | Description |\n"
+	envVarsTable += "|--|--|--|\n"
+	fs.VisitAll(func(f *flag.Flag) {
+		if f.DefValue == "" {
+			envVarsTable += fmt.Sprintf("| %s | %s | %s|\n", strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_"), "\\-\\-"+f.Name, f.Usage)
+		} else {
+			envVarsTable += fmt.Sprintf("| %s | %s | %s (default = %s)|\n", strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_"), "\\-\\-"+f.Name, f.Usage, f.DefValue)
+		}
+	})
+
+	log.Println("writing output to", outputFileName)
+	err := os.WriteFile(outputFileName, []byte(title+comment+description+envVarsTable), 0644)
+	if err != nil {
+		log.Fatalf("failed to write file %s, %s", outputFileName, err)
+	}
+}


### PR DESCRIPTION
This PR introduces a new user-facing document (`settings.md`) that lists configurable environment variables and CLI flags for the `karpenter-clusterapi-controller`.

To ensure the documentation remains up-to-date, a Go-based generator script (`hack/docs/settings_gen/main.go`) has been added. This script extracts configuration definitions from the source code, ensuring that any updates to flag descriptions are automatically reflected in the generated documentation.

The necessity of this documentation was mentioned in PR #41

### Changes:
- Added `docs/docs/settings.md` to describe available controller settings
- Added `hack/docs/settings_gen/main.go` to auto-generate the documentation
- Designed the documentation to be regenerated via script to reduce manual maintenance

This improves transparency for users and maintainers, and helps ensure configuration options are consistently documented.