### PR TITLE
chore(ci): introduce github actions workflow to automate release tasks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v*-test'
+jobs:
+  release:
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.repository == 'kubernetes-sigs/karpenter-provider-cluster-api'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+    - run: make docgen
+    - run: make release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPO: ${{ github.repository }}
+    - name: create pull request
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          await github.rest.pulls.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `chore(release): release ${context.ref_name} (automated)`,
+            head: `release-${context.ref_name}`,
+            base: 'main',
+            body: `Release Changes for \`${context.ref_name}\`
+
+            ### Changes included:
+            - Created release branch \`release-${context.ref_name}\`
+            - Automatically generated documentation
+            - Bumped Helm chart version to \`${context.ref_name}\`
+
+            This PR was generated automatically by karpenter-provider-cluster-api/.github/workflows/release.yml
+            `
+            draft: false
+          });

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,11 @@ vendor: ## update modules and populate local vendor directory
 	go mod tidy
 	go mod vendor
 	go mod verify
+
+.PHONY: docgen
+docgen: ## Generate documentation files
+	./hack/docgen.sh
+
+.PHONY: release
+release: ## Create a release branch, update chart version, and push changes
+	./hack/release.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ The Kubernetes Template Project is released on an as-needed basis. The process i
 
 1. An issue is proposing a new release with a changelog since the last release
 2. All [OWNERS](OWNERS) must LGTM this release
-3. Bump the `version` and `appVersion` of the Helm chart in `charts/karpenter/Chart.yaml`
-4. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
+3. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
+4. All [OWNERS](OWNERS) must approve the release PR automatically created by GitHub Actions
 5. The release issue is closed
 6. An announcement email is sent to `dev@kubernetes.io` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`

--- a/hack/docgen.sh
+++ b/hack/docgen.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu -o pipefail
+
+go run hack/docs/settings_gen/main.go docs/docs/settings.md

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu -o pipefail
+
+git_tag="$(git describe --exact-match --tags || echo "none")"
+if [[ "${git_tag}" != v* ]]; then
+  echo "::notice::This commit is no tagged."
+  exit 1
+fi
+
+git config user.name "Release"
+git config user.email "release@users.noreply.github.com"
+git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO}"
+
+branch_name="release-${git_tag}"
+git checkout -b "${branch_name}"
+
+# Bump the version and appVersion of the Helm chart in charts/karpenter/Chart.yaml
+sed -i "s/^appVersion: .*/appVersion: \"${git_tag#v}\"/" charts/karpenter/Chart.yaml
+sed -i "s/^version: .*/version: ${git_tag#v}/" charts/karpenter/Chart.yaml
+
+git add go.mod
+git add go.sum
+git add docs/docs
+git add charts/karpenter
+git commit -m "chore(release): release ${git_tag} (automated)"
+git push --set-upstream origin "${branch_name}"


### PR DESCRIPTION
## Summary

This PR introduces a GitHub Actions workflow to automate release tasks triggered by tag pushes.

## Changes Included

- Adds `.github/workflows/release.yml` to define the release workflow
- Integrates `docgen.sh` and `release.sh` scripts for documentation generation and the release tasks including Helm chart version bump and the creation of a release branch  (`release-v*`)
- Adds corresponding Makefile targets (`docgen`, `release`) for CI integration
- Automatically opens a pull request with the updated files
- Updates `RELEASE.md` to reflect the new release flow and approval process, as Helm chart version bumping is now automated.

## Workflow Overview

When a tag matching `v*` or `v*-test` is pushed:
1. Documentation is generated via `make docgen`
2. Helm chart version is bumped and the changes are committed and pushed as the `release-v*` branch via `make release`
3. A pull request is automatically opened targeting `main`

## Notes

- The release PR includes changes to `go.mod`, `go.sum`, `docs/docs`, and `charts/karpenter`
- While some parts of the workflow have been verified, push and pull request creation could not be tested. To enable safe testing of the full workflow, a `v*-test` tag trigger was added.
- The necessity of this GitHub Actions workflow was mentioned in 
  PR: #44

This automation improves release consistency and reduces manual effort.