### PR TITLE
Improve error handling with meaningful context across providers

### DIFF
--- a/pkg/controllers/nodeclass/status/controller.go
+++ b/pkg/controllers/nodeclass/status/controller.go
@@ -18,6 +18,7 @@ package status
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/awslabs/operatorpkg/status"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -63,7 +64,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1alpha1.ClusterA
 			if errors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}
-			return reconcile.Result{}, err
+			return reconcile.Result{}, fmt.Errorf("unable to patch NodeClass status for %s: %w", nodeClass.Name, err)
 		}
 	}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -18,6 +18,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/samber/lo"
@@ -73,7 +74,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 func buildManagementClusterKubeClient(ctx context.Context, operator *operator.Operator) (client.Client, error) {
 	clusterAPIKubeConfig, err := buildClusterCAPIKubeConfig(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to build cluster API kube config: %w", err)
 	}
 
 	if clusterAPIKubeConfig != nil {
@@ -81,10 +82,10 @@ func buildManagementClusterKubeClient(ctx context.Context, operator *operator.Op
 			o.Scheme = operator.GetScheme()
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to create new cluster for management cluster: %w", err)
 		}
 		if err = operator.Add(mgmtCluster); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to add management cluster to operator: %w", err)
 		}
 		return mgmtCluster.GetClient(), nil
 	}

--- a/pkg/providers/machine/machine.go
+++ b/pkg/providers/machine/machine.go
@@ -79,7 +79,7 @@ func (p *DefaultProvider) List(ctx context.Context, selector *metav1.LabelSelect
 	machineList := &capiv1beta1.MachineList{}
 	err := p.kubeClient.List(ctx, machineList, listOptions...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to list machines with selector: %w", err)
 	}
 
 	for _, m := range machineList.Items {

--- a/pkg/providers/machinedeployment/machinedeployment.go
+++ b/pkg/providers/machinedeployment/machinedeployment.go
@@ -47,8 +47,9 @@ func (p *DefaultProvider) Get(ctx context.Context, name string, namespace string
 	err := p.kubeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, machineDeployment)
 	if err != nil {
 		machineDeployment = nil
+		return machineDeployment, fmt.Errorf("unable to get MachineDeployment %s in namespace %s: %w", name, namespace, err)
 	}
-	return machineDeployment, err
+	return machineDeployment, nil
 }
 
 func (p *DefaultProvider) List(ctx context.Context, selector *metav1.LabelSelector) ([]*capiv1beta1.MachineDeployment, error) {
@@ -70,7 +71,7 @@ func (p *DefaultProvider) List(ctx context.Context, selector *metav1.LabelSelect
 	machineDeploymentList := &capiv1beta1.MachineDeploymentList{}
 	err := p.kubeClient.List(ctx, machineDeploymentList, listOptions...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to list MachineDeployments with selector: %w", err)
 	}
 
 	for _, m := range machineDeploymentList.Items {


### PR DESCRIPTION
https://github.com/kubernetes-sigs/karpenter-provider-cluster-api/issues/2

### Summary
Improves error handling by adding meaningful context to error returns that were previously wrapped without additional information. This makes debugging easier by providing clear information about which operation failed and on which resources.

## Testing
- [x] Code builds successfully (go build ./...)
- [x] No breaking changes to existing functionality
- [x] Error message format consistent with existing codebase patterns