### PR TITLE
Tolerate Machine ProviderID to support slow Infrastructure Providers

### DIFF
--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -103,7 +103,7 @@ var _ = Describe("CloudProvider.Delete method", func() {
 		nodeClaim := karpv1.NodeClaim{}
 		nodeClaim.Name = "some-node-claim"
 		err := provider.Delete(context.Background(), &nodeClaim)
-		Expect(err).To(MatchError(fmt.Errorf("NodeClaim %q does not have a provider ID, cannot delete", nodeClaim.Name)))
+		Expect(err).To(MatchError(fmt.Errorf("NodeClaim %q does not have a provider ID or Machine annotations, cannot delete", nodeClaim.Name)))
 	})
 
 	It("returns an error when the referenced Machine is not found", func() {
@@ -193,7 +193,7 @@ var _ = Describe("CloudProvider.Delete method", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() map[string]string {
-			m, err := provider.machineProvider.Get(context.Background(), providerID)
+			m, err := provider.machineProvider.GetByProviderID(context.Background(), providerID)
 			Expect(err).ToNot(HaveOccurred())
 			return m.GetAnnotations()
 		}).Should(HaveKey(capiv1beta1.DeleteMachineAnnotation))

--- a/pkg/providers/machine/machine_test.go
+++ b/pkg/providers/machine/machine_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Machine DefaultProvider.Get method", func() {
 	})
 
 	It("returns nil when there are no Machines present in API", func() {
-		machine, err := provider.Get(context.Background(), "")
+		machine, err := provider.GetByProviderID(context.Background(), "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machine).To(BeNil())
 	})
@@ -86,7 +86,7 @@ var _ = Describe("Machine DefaultProvider.Get method", func() {
 		machine := newMachine("karpenter-1", "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
-		machine, err := provider.Get(context.Background(), "clusterapi://the-wrong-provider-id")
+		machine, err := provider.GetByProviderID(context.Background(), "clusterapi://the-wrong-provider-id")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machine).To(BeNil())
 	})
@@ -98,7 +98,7 @@ var _ = Describe("Machine DefaultProvider.Get method", func() {
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
 		providerID := *machine.Spec.ProviderID
-		machine, err := provider.Get(context.Background(), providerID)
+		machine, err := provider.GetByProviderID(context.Background(), providerID)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machine).Should(HaveField("Name", "karpenter-2"))
 	})
@@ -110,7 +110,7 @@ var _ = Describe("Machine DefaultProvider.Get method", func() {
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
 		providerID := *machine.Spec.ProviderID
-		machine, err := provider.Get(context.Background(), providerID)
+		machine, err := provider.GetByProviderID(context.Background(), providerID)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machine).Should(HaveField("Name", "karpenter-2"))
 	})
@@ -213,7 +213,7 @@ var _ = Describe("Machine DefaultProvider.AddDeleteAnnotation method", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() map[string]string {
-			m, err := provider.Get(context.Background(), *machine.Spec.ProviderID)
+			m, err := provider.GetByProviderID(context.Background(), *machine.Spec.ProviderID)
 			Expect(err).ToNot(HaveOccurred())
 			return m.GetAnnotations()
 		}).Should(HaveKey(capiv1beta1.DeleteMachineAnnotation))
@@ -263,7 +263,7 @@ var _ = Describe("Machine DefaultProvider.RemoveDeleteAnnotation method", func()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() map[string]string {
-			m, err := provider.Get(context.Background(), *machine.Spec.ProviderID)
+			m, err := provider.GetByProviderID(context.Background(), *machine.Spec.ProviderID)
 			Expect(err).ToNot(HaveOccurred())
 			return m.GetAnnotations()
 		}).ShouldNot(HaveKey(capiv1beta1.DeleteMachineAnnotation))


### PR DESCRIPTION
This change updates the CloudProvider reconciliation logic to allow the use of a newly created CAPI Machine even if it does not immediately have the ProviderID set.

Currently, the reconciliation will revert the MachineDeployment's replica count and delete the Machine if ProviderID is not assigned within the timeout period. This is problematic for InfrastructureProviders that require significant time to set the ProviderID.

This change allows the reconciliation to proceed with the Machine's creation, preventing premature deletion and supporting providers that have a slow time-to-providerID. The system will continue to wait for the Machine to eventually obtain a ProviderID. This enhances compatibility with slow-to-provision infrastructures.