### PR TITLE
chore(release): add cloudbuild.yaml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,9 @@ ARCH ?= $(shell go env GOARCH)
 
 CONTAINER_RUNTIME ?= docker
 BUILDER_IMAGE ?=
-IMG ?= karpenter-clusterapi-controller
+REGISTRY ?= gcr.io/k8s-staging-karpenter-cluster-api
+TAG ?= latest
+IMG ?= $(REGISTRY)/karpenter-clusterapi-controller:$(TAG)
 
 all: help
 
@@ -51,6 +53,13 @@ karpenter-clusterapi-controller: ## build the main karpenter controller
 .PHONY: image
 image: ## Build manager container image
 	$(CONTAINER_RUNTIME) build --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg ARCH=$(ARCH) . -t $(IMG)
+
+.PHONY: image-push
+image-push: ## Push the manager container image to the container registry
+	$(CONTAINER_RUNTIME) push $(IMG)
+
+.PHONY: release-staging ## Build and push the staging image to the registry.
+release-staging: image image-push
 
 .PHONY: manifests
 manifests: ## generate the controller-gen kubernetes manifests

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,20 @@
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest'
+  entrypoint: make
+  env:
+    - TAG=$_GIT_TAG
+  args:
+    - release-staging
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '0.0.0'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'main'
+images:
+- 'gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller:$_GIT_TAG'


### PR DESCRIPTION
Related to: https://github.com/kubernetes-sigs/karpenter-provider-cluster-api/issues/18

Went through this documentation: https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#cloudbuildyaml

Some things to note:
* We are okay with this being the staging image name? `karpenter-clusterapi-controller:whatever-git-tag`
* I tested this `cloudbuild.yaml` file with my own personal gcloud account and project, and pushing to my own repository (`https://quay.io/repository/macao/karpenter-clusterapi-controller`)
   * I can't test this with the actual staging repo (and I probably shouldn't have access to do that anyways)

I will need to create a prow job in the next steps of that documentation after this is merged.