### PR TITLE
chore(ci): fix github actions release.yml to resolve SyntaxError

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,20 +25,21 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          const tag = context.ref.replace("refs/tags/", '');
           await github.rest.pulls.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: `chore(release): release ${context.ref_name} (automated)`,
-            head: `release-${context.ref_name}`,
+            title: `chore(release): release ${tag} (automated)`,
+            head: `release-${tag}`,
             base: 'main',
-            body: `Release Changes for \`${context.ref_name}\`
+            draft: false,
+            body: `Release Changes for \`${tag}\`
 
             ### Changes included:
-            - Created release branch \`release-${context.ref_name}\`
+            - Created release branch \`release-${tag}\`
             - Automatically generated documentation
-            - Bumped Helm chart version to \`${context.ref_name}\`
+            - Bumped Helm chart version to \`${tag}\`
 
             This PR was generated automatically by karpenter-provider-cluster-api/.github/workflows/release.yml
             `
-            draft: false
           });


### PR DESCRIPTION
### Summary
This PR fixes a syntax error in `.github/workflows/release.yml` that was preventing automated pull request creation during tagged releases, addressing issue #53  in the process.

### Changes
- Added a missing comma in the github-script block to fix the `SyntaxError: Unexpected identifier 'draft'` error.
- Proactively replaced incorrect usage of `context.ref_name` with a properly extracted tag from `context.ref`, resolving a syntax error and preventing future issues.



