### PR TITLE
Fix cloudbuild to include an extra tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,20 +1,22 @@
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:
-  substitution_option: ALLOW_LOOSE
+  substitutionOption: ALLOW_LOOSE
 steps:
 - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest'
   entrypoint: make
   env:
-    - TAG=$_GIT_TAG
+    - IMG_REPO=gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller
+    - IMG_TAG=$_GIT_TAG
+    - EXTRA_TAG=$_PULL_BASE_REF
+    - DOCKER_BUILDX_CMD=/buildx-entrypoint
   args:
-    - release-staging
+    - image-push
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: '0.0.0'
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
-  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  # a branch like 'main' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'main'
-images:
-- 'gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller:$_GIT_TAG'
+timeout: 1200s # 20 minutes


### PR DESCRIPTION
Followup to https://github.com/kubernetes-sigs/karpenter-provider-cluster-api/pull/54

This commit improves the `Makefile` to allow more configurable build options. Also includes an EXTRA_TAG variable so automatic builds push images with branch name tags.

Related to https://github.com/kubernetes/test-infra/pull/35802 because I realized we probably want to automatically push stage images based on our release branches.

Took inspiration from this `Makefile`: https://github.com/kubernetes-sigs/lws/blob/main/Makefile

Tested with my own repository and injected credentials:
```
$ gcloud builds submit --config=cloudbuild.yaml
...omitted
#17 pushing quay.io/macao/my-karpenter-test:main with docker
#17 pushing layer 8fa10c0194df 0.7s done
...omitted...
#17 DONE 0.7s

#5 [stage-1 1/3] FROM gcr.io/distroless/static:nonroot-amd64@sha256:127eb3c971acb50a3c7b511a978bb497b56add4c91225e57605b3b43cc0a9662
PUSH
DONE
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ID                                    CREATE_TIME                DURATION  SOURCE                                                                                        IMAGES  STATUS
d4885e4a-0c40-468c-a142-d676a88b3191  2025-10-29T20:41:50+00:00  5M40S     gs://default-476521_cloudbuild/source/1761770498.694338-c5c121acf11b415ca19d198fb59c3088.tgz  -       SUCCESS
```