### PR TITLE
docs(repo): add ISSUE_TEMPLATES and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,22 @@
+name: Bug
+description: Report a bug
+labels: ['kind/bug']
+body:
+- type: textarea
+  attributes:
+    label: Description
+    value: |
+      **Observed Behavior**:
+
+      **Expected Behavior**:
+
+      **Reproduction Steps** (Please include YAML):
+
+      **Versions**:
+      - Karpenter Cluster-API Provider Version:
+      - Cluster-API Version and Provider:
+      - Kubernetes Version (`kubectl version`):
+
+      * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+      * Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
+      * If you are interested in working on this issue or have submitted a pull request, please leave a comment

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,15 @@
+name: Feature
+description: Suggest an idea for a new feature
+labels: ['kind/feature']
+body:
+- type: textarea
+  attributes:
+    label: Description
+    value: |
+      **What problem are you trying to solve?**
+
+      **How important is this feature to you?**
+
+      * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+      * Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
+      * If you are interested in working on this issue or have submitted a pull request, please leave a comment

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,18 @@
+<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
+feat:            <-- New features that require a MINOR version update
+fix:             <-- Bug fixes that require at PATCH version update
+chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
+perf:            <-- Code changes that improve performance but do not impact behavior
+docs:            <-- Documentation changes that do not impact code
+test:            <-- Test changes that do not impact behavior
+ci:              <-- Changes that affect test or rollout automation
+!${type}:        <-- Include ! if your change includes a backwards incompatible change.
+-->
+
+Fixes #N/A <!-- issue number -->
+
+**Description**
+
+**How was this change tested?**
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
I took inspiration from the templates from the kubernetes-sigs/karpenter repo: https://github.com/kubernetes-sigs/karpenter/tree/main/.github

You can see what it looks like on my own repo if you try to open PRs or issues on it: 
issues: https://github.com/maxcao13/karpenter-provider-cluster-api/issues
prs: https://github.com/maxcao13/karpenter-provider-cluster-api/pulls