### PR TITLE
chore(deps): update Karpenter upstream crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ image-push: image-build$(USE_DOCKER)
 .PHONY: manifests
 manifests: ## generate the controller-gen kubernetes manifests
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd paths="./..." output:crd:artifacts:config=pkg/apis/crds
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd paths="./vendor/sigs.k8s.io/karpenter/..." output:crd:artifacts:config=pkg/apis/crds
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd paths="./vendor/sigs.k8s.io/karpenter/pkg/apis/..." output:crd:artifacts:config=pkg/apis/crds
 
 .PHONY: test
 test: vendor unit ## vendor the dependencies and run unit tests

--- a/pkg/apis/crds/karpenter.cluster.x-k8s.io_clusterapinodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.cluster.x-k8s.io_clusterapinodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: clusterapinodeclasses.karpenter.cluster.x-k8s.io
 spec:
   group: karpenter.cluster.x-k8s.io
@@ -146,12 +146,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh
@@ -35,6 +35,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.imageID
+      name: ImageID
+      priority: 1
+      type: string
     - jsonPath: .status.providerID
       name: ID
       priority: 1
@@ -45,6 +49,10 @@ spec:
       type: string
     - jsonPath: .spec.nodeClassRef.name
       name: NodeClass
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Drifted")].status
+      name: Drifted
       priority: 1
       type: string
     name: v1
@@ -79,7 +87,7 @@ spec:
                   before terminating a node, measured from when the node is created. This
                   is useful to implement features like eventually consistent node upgrade,
                   memory leak protection, and disruption testing.
-                pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                pattern: ^(([0-9]+(s|m|h))+|Never)$
                 type: string
               nodeClassRef:
                 description: NodeClassRef is a reference to an object that defines
@@ -89,12 +97,21 @@ spec:
                     description: API version of the referent
                     pattern: ^[^/]*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: group may not be empty
+                      rule: self != ''
                   kind:
                     description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                     type: string
+                    x-kubernetes-validations:
+                    - message: kind may not be empty
+                      rule: self != ''
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                     type: string
+                    x-kubernetes-validations:
+                    - message: name may not be empty
+                      rule: self != ''
                 required:
                 - group
                 - kind
@@ -235,18 +252,14 @@ spec:
                 description: |-
                   TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
-
                   Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
 
                   This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
                   When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
 
-
                   Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
                   If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
                   that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
 
                   The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
                   If left undefined, the controller will wait indefinitely for pods to be drained.
@@ -326,12 +339,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -366,434 +374,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
-      name: Type
-      type: string
-    - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
-      name: Zone
-      type: string
-    - jsonPath: .status.nodeName
-      name: Node
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
-      name: Capacity
-      priority: 1
-      type: string
-    - jsonPath: .metadata.labels.karpenter\.sh/nodepool
-      name: NodePool
-      priority: 1
-      type: string
-    - jsonPath: .spec.nodeClassRef.name
-      name: NodeClass
-      priority: 1
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: NodeClaim is the Schema for the NodeClaims API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: NodeClaimSpec describes the desired state of the NodeClaim
-            properties:
-              kubelet:
-                description: |-
-                  Kubelet defines args to be used when configuring kubelet on provisioned nodes.
-                  They are a subset of the upstream types, recognizing not all options may be supported.
-                  Wherever possible, the types and names should reflect the upstream kubelet types.
-                properties:
-                  clusterDNS:
-                    description: |-
-                      clusterDNS is a list of IP addresses for the cluster DNS server.
-                      Note that not all providers may use all addresses.
-                    items:
-                      type: string
-                    type: array
-                  cpuCFSQuota:
-                    description: CPUCFSQuota enables CPU CFS quota enforcement for
-                      containers that specify CPU limits.
-                    type: boolean
-                  evictionHard:
-                    additionalProperties:
-                      type: string
-                    description: EvictionHard is the map of signal names to quantities
-                      that define hard eviction thresholds
-                    type: object
-                    x-kubernetes-validations:
-                    - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
-                      rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
-                  evictionMaxPodGracePeriod:
-                    description: |-
-                      EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
-                      response to soft eviction thresholds being met.
-                    format: int32
-                    type: integer
-                  evictionSoft:
-                    additionalProperties:
-                      type: string
-                    description: EvictionSoft is the map of signal names to quantities
-                      that define soft eviction thresholds
-                    type: object
-                    x-kubernetes-validations:
-                    - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
-                      rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
-                  evictionSoftGracePeriod:
-                    additionalProperties:
-                      type: string
-                    description: EvictionSoftGracePeriod is the map of signal names
-                      to quantities that define grace periods for each eviction signal
-                    type: object
-                    x-kubernetes-validations:
-                    - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
-                      rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
-                  imageGCHighThresholdPercent:
-                    description: |-
-                      ImageGCHighThresholdPercent is the percent of disk usage after which image
-                      garbage collection is always run. The percent is calculated by dividing this
-                      field value by 100, so this field must be between 0 and 100, inclusive.
-                      When specified, the value must be greater than ImageGCLowThresholdPercent.
-                    format: int32
-                    maximum: 100
-                    minimum: 0
-                    type: integer
-                  imageGCLowThresholdPercent:
-                    description: |-
-                      ImageGCLowThresholdPercent is the percent of disk usage before which image
-                      garbage collection is never run. Lowest disk usage to garbage collect to.
-                      The percent is calculated by dividing this field value by 100,
-                      so the field value must be between 0 and 100, inclusive.
-                      When specified, the value must be less than imageGCHighThresholdPercent
-                    format: int32
-                    maximum: 100
-                    minimum: 0
-                    type: integer
-                  kubeReserved:
-                    additionalProperties:
-                      type: string
-                    description: KubeReserved contains resources reserved for Kubernetes
-                      system components.
-                    type: object
-                    x-kubernetes-validations:
-                    - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
-                      rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage'
-                        || x=='pid')
-                    - message: kubeReserved value cannot be a negative resource quantity
-                      rule: self.all(x, !self[x].startsWith('-'))
-                  maxPods:
-                    description: |-
-                      MaxPods is an override for the maximum number of pods that can run on
-                      a worker node instance.
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  podsPerCore:
-                    description: |-
-                      PodsPerCore is an override for the number of pods that can run on a worker node
-                      instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
-                      MaxPods is a lower value, that value will be used.
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  systemReserved:
-                    additionalProperties:
-                      type: string
-                    description: SystemReserved contains resources reserved for OS
-                      system daemons and kernel memory.
-                    type: object
-                    x-kubernetes-validations:
-                    - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
-                      rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage'
-                        || x=='pid')
-                    - message: systemReserved value cannot be a negative resource
-                        quantity
-                      rule: self.all(x, !self[x].startsWith('-'))
-                type: object
-                x-kubernetes-validations:
-                - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
-                  rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent)
-                    ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  :
-                    true'
-                - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
-                  rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
-                - message: evictionSoftGracePeriod OwnerKey does not have a matching
-                    evictionSoft
-                  rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e,
-                    (e in self.evictionSoft)):true
-              nodeClassRef:
-                description: NodeClassRef is a reference to an object that defines
-                  provider specific configuration
-                properties:
-                  apiVersion:
-                    description: API version of the referent
-                    type: string
-                  kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                    type: string
-                  name:
-                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                required:
-                - name
-                type: object
-              requirements:
-                description: Requirements are layered with GetLabels and applied to
-                  every node.
-                items:
-                  description: |-
-                    A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
-                    and minValues that represent the requirement to have at least that many values.
-                  properties:
-                    key:
-                      description: The label key that the selector applies to.
-                      type: string
-                    minValues:
-                      description: |-
-                        This field is ALPHA and can be dropped or replaced at any time
-                        MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
-                      maximum: 50
-                      minimum: 1
-                      type: integer
-                    operator:
-                      description: |-
-                        Represents a key's relationship to a set of values.
-                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                      type: string
-                    values:
-                      description: |-
-                        An array of string values. If the operator is In or NotIn,
-                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                        the values array must be empty. If the operator is Gt or Lt, the values
-                        array must have a single element, which will be interpreted as an integer.
-                        This array is replaced during a strategic merge patch.
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                  required:
-                  - key
-                  - operator
-                  type: object
-                maxItems: 100
-                type: array
-                x-kubernetes-validations:
-                - message: requirements with operator 'In' must have a value defined
-                  rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 :
-                    true)'
-                - message: requirements operator 'Gt' or 'Lt' must have a single positive
-                    integer value
-                  rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'')
-                    ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
-                - message: requirements with 'minValues' must have at least that many
-                    values specified in the 'values' field
-                  rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ?
-                    x.values.size() >= x.minValues : true)'
-              resources:
-                description: Resources models the resource requirements for the NodeClaim
-                  to launch
-                properties:
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: Requests describes the minimum required resources
-                      for the NodeClaim to launch
-                    type: object
-                type: object
-              startupTaints:
-                description: |-
-                  StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
-                  within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
-                  daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
-                  purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
-                items:
-                  description: |-
-                    The node this Taint is attached to has the "effect" on
-                    any pod that does not tolerate the Taint.
-                  properties:
-                    effect:
-                      description: |-
-                        Required. The effect of the taint on pods
-                        that do not tolerate the taint.
-                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Required. The taint key to be applied to a node.
-                      type: string
-                    timeAdded:
-                      description: |-
-                        TimeAdded represents the time at which the taint was added.
-                        It is only written for NoExecute taints.
-                      format: date-time
-                      type: string
-                    value:
-                      description: The taint value corresponding to the taint key.
-                      type: string
-                  required:
-                  - effect
-                  - key
-                  type: object
-                type: array
-              taints:
-                description: Taints will be applied to the NodeClaim's node.
-                items:
-                  description: |-
-                    The node this Taint is attached to has the "effect" on
-                    any pod that does not tolerate the Taint.
-                  properties:
-                    effect:
-                      description: |-
-                        Required. The effect of the taint on pods
-                        that do not tolerate the taint.
-                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Required. The taint key to be applied to a node.
-                      type: string
-                    timeAdded:
-                      description: |-
-                        TimeAdded represents the time at which the taint was added.
-                        It is only written for NoExecute taints.
-                      format: date-time
-                      type: string
-                    value:
-                      description: The taint value corresponding to the taint key.
-                      type: string
-                  required:
-                  - effect
-                  - key
-                  type: object
-                type: array
-            required:
-            - nodeClassRef
-            - requirements
-            type: object
-          status:
-            description: NodeClaimStatus defines the observed state of NodeClaim
-            properties:
-              allocatable:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Allocatable is the estimated allocatable capacity of
-                  the node
-                type: object
-              capacity:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Capacity is the estimated full capacity of the node
-                type: object
-              conditions:
-                description: Conditions contains signals for health and readiness
-                items:
-                  description: Condition aliases the upstream type and adds additional
-                    helper methods
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              imageID:
-                description: ImageID is an identifier for the image that runs on the
-                  node
-                type: string
-              nodeName:
-                description: NodeName is the name of the corresponding node object
-                type: string
-              providerID:
-                description: ProviderID of the corresponding node object
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
     subresources:
       status: {}

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh
@@ -146,7 +146,7 @@ spec:
                       ConsolidateAfter is the duration the controller will wait
                       before attempting to terminate nodes that are underutilized.
                       Refer to ConsolidationPolicy for how underutilization is considered.
-                    pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                    pattern: ^(([0-9]+(s|m|h))+|Never)$
                     type: string
                   consolidationPolicy:
                     default: WhenEmptyOrUnderutilized
@@ -208,7 +208,7 @@ spec:
                           before terminating a node, measured from when the node is created. This
                           is useful to implement features like eventually consistent node upgrade,
                           memory leak protection, and disruption testing.
-                        pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                        pattern: ^(([0-9]+(s|m|h))+|Never)$
                         type: string
                       nodeClassRef:
                         description: NodeClassRef is a reference to an object that
@@ -218,17 +218,31 @@ spec:
                             description: API version of the referent
                             pattern: ^[^/]*$
                             type: string
+                            x-kubernetes-validations:
+                            - message: group may not be empty
+                              rule: self != ''
                           kind:
                             description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                             type: string
+                            x-kubernetes-validations:
+                            - message: kind may not be empty
+                              rule: self != ''
                           name:
                             description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
+                            x-kubernetes-validations:
+                            - message: name may not be empty
+                              rule: self != ''
                         required:
                         - group
                         - kind
                         - name
                         type: object
+                        x-kubernetes-validations:
+                        - message: nodeClassRef.group is immutable
+                          rule: self.group == oldSelf.group
+                        - message: nodeClassRef.kind is immutable
+                          rule: self.kind == oldSelf.kind
                       requirements:
                         description: Requirements are layered with GetLabels and applied
                           to every node.
@@ -356,18 +370,14 @@ spec:
                         description: |-
                           TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
-
                           Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
 
                           This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
                           When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
 
-
                           Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
                           If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
                           that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
 
                           The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
                           If left undefined, the controller will wait indefinitely for pods to be drained.
@@ -441,12 +451,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -458,6 +463,12 @@ spec:
                   - type
                   type: object
                 type: array
+              nodeClassObservedGeneration:
+                description: |-
+                  NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match
+                  the actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset
+                format: int64
+                type: integer
               resources:
                 additionalProperties:
                   anyOf:
@@ -473,558 +484,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .spec.template.spec.nodeClassRef.name
-      name: NodeClass
-      type: string
-    - jsonPath: .spec.weight
-      name: Weight
-      priority: 1
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: NodePool is the Schema for the NodePools API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: |-
-              NodePoolSpec is the top level nodepool specification. Nodepools
-              launch nodes in response to pods that are unschedulable. A single nodepool
-              is capable of managing a diverse set of nodes. Node properties are determined
-              from a combination of nodepool and pod scheduling constraints.
-            properties:
-              disruption:
-                default:
-                  consolidationPolicy: WhenUnderutilized
-                  expireAfter: 720h
-                description: Disruption contains the parameters that relate to Karpenter's
-                  disruption logic
-                properties:
-                  budgets:
-                    default:
-                    - nodes: 10%
-                    description: |-
-                      Budgets is a list of Budgets.
-                      If there are multiple active budgets, Karpenter uses
-                      the most restrictive value. If left undefined,
-                      this will default to one budget with a value to 10%.
-                    items:
-                      description: |-
-                        Budget defines when Karpenter will restrict the
-                        number of Node Claims that can be terminating simultaneously.
-                      properties:
-                        duration:
-                          description: |-
-                            Duration determines how long a Budget is active since each Schedule hit.
-                            Only minutes and hours are accepted, as cron does not work in seconds.
-                            If omitted, the budget is always active.
-                            This is required if Schedule is set.
-                            This regex has an optional 0s at the end since the duration.String() always adds
-                            a 0s at the end.
-                          pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
-                          type: string
-                        nodes:
-                          default: 10%
-                          description: |-
-                            Nodes dictates the maximum number of NodeClaims owned by this NodePool
-                            that can be terminating at once. This is calculated by counting nodes that
-                            have a deletion timestamp set, or are actively being deleted by Karpenter.
-                            This field is required when specifying a budget.
-                            This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
-                            checking for int nodes for IntOrString nodes.
-                            Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
-                          pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
-                          type: string
-                        schedule:
-                          description: |-
-                            Schedule specifies when a budget begins being active, following
-                            the upstream cronjob syntax. If omitted, the budget is always active.
-                            Timezones are not supported.
-                            This field is required if Duration is set.
-                          pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
-                          type: string
-                      required:
-                      - nodes
-                      type: object
-                    maxItems: 50
-                    type: array
-                    x-kubernetes-validations:
-                    - message: '''schedule'' must be set with ''duration'''
-                      rule: self.all(x, has(x.schedule) == has(x.duration))
-                  consolidateAfter:
-                    description: |-
-                      ConsolidateAfter is the duration the controller will wait
-                      before attempting to terminate nodes that are underutilized.
-                      Refer to ConsolidationPolicy for how underutilization is considered.
-                    pattern: ^(([0-9]+(s|m|h))+)|(Never)$
-                    type: string
-                  consolidationPolicy:
-                    default: WhenUnderutilized
-                    description: |-
-                      ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
-                      algorithm. This policy defaults to "WhenUnderutilized" if not specified
-                    enum:
-                    - WhenEmpty
-                    - WhenUnderutilized
-                    type: string
-                  expireAfter:
-                    default: 720h
-                    description: |-
-                      ExpireAfter is the duration the controller will wait
-                      before terminating a node, measured from when the node is created. This
-                      is useful to implement features like eventually consistent node upgrade,
-                      memory leak protection, and disruption testing.
-                    pattern: ^(([0-9]+(s|m|h))+)|(Never)$
-                    type: string
-                type: object
-                x-kubernetes-validations:
-                - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
-                  rule: 'has(self.consolidateAfter) ? self.consolidationPolicy !=
-                    ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' :
-                    true'
-                - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
-                  rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter)
-                    : true'
-              limits:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Limits define a set of bounds for provisioning capacity.
-                type: object
-              template:
-                description: |-
-                  Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
-                  NodeClaims launched from this NodePool will often be further constrained than the template specifies.
-                properties:
-                  metadata:
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
-                        type: object
-                      labels:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          Map of string keys and values that can be used to organize and categorize
-                          (scope and select) objects. May match selectors of replication controllers
-                          and services.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-                        type: object
-                    type: object
-                  spec:
-                    description: NodeClaimSpec describes the desired state of the
-                      NodeClaim
-                    properties:
-                      kubelet:
-                        description: |-
-                          Kubelet defines args to be used when configuring kubelet on provisioned nodes.
-                          They are a subset of the upstream types, recognizing not all options may be supported.
-                          Wherever possible, the types and names should reflect the upstream kubelet types.
-                        properties:
-                          clusterDNS:
-                            description: |-
-                              clusterDNS is a list of IP addresses for the cluster DNS server.
-                              Note that not all providers may use all addresses.
-                            items:
-                              type: string
-                            type: array
-                          cpuCFSQuota:
-                            description: CPUCFSQuota enables CPU CFS quota enforcement
-                              for containers that specify CPU limits.
-                            type: boolean
-                          evictionHard:
-                            additionalProperties:
-                              type: string
-                            description: EvictionHard is the map of signal names to
-                              quantities that define hard eviction thresholds
-                            type: object
-                            x-kubernetes-validations:
-                            - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
-                              rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
-                          evictionMaxPodGracePeriod:
-                            description: |-
-                              EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
-                              response to soft eviction thresholds being met.
-                            format: int32
-                            type: integer
-                          evictionSoft:
-                            additionalProperties:
-                              type: string
-                            description: EvictionSoft is the map of signal names to
-                              quantities that define soft eviction thresholds
-                            type: object
-                            x-kubernetes-validations:
-                            - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
-                              rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
-                          evictionSoftGracePeriod:
-                            additionalProperties:
-                              type: string
-                            description: EvictionSoftGracePeriod is the map of signal
-                              names to quantities that define grace periods for each
-                              eviction signal
-                            type: object
-                            x-kubernetes-validations:
-                            - message: valid keys for evictionSoftGracePeriod are
-                                ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
-                              rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
-                          imageGCHighThresholdPercent:
-                            description: |-
-                              ImageGCHighThresholdPercent is the percent of disk usage after which image
-                              garbage collection is always run. The percent is calculated by dividing this
-                              field value by 100, so this field must be between 0 and 100, inclusive.
-                              When specified, the value must be greater than ImageGCLowThresholdPercent.
-                            format: int32
-                            maximum: 100
-                            minimum: 0
-                            type: integer
-                          imageGCLowThresholdPercent:
-                            description: |-
-                              ImageGCLowThresholdPercent is the percent of disk usage before which image
-                              garbage collection is never run. Lowest disk usage to garbage collect to.
-                              The percent is calculated by dividing this field value by 100,
-                              so the field value must be between 0 and 100, inclusive.
-                              When specified, the value must be less than imageGCHighThresholdPercent
-                            format: int32
-                            maximum: 100
-                            minimum: 0
-                            type: integer
-                          kubeReserved:
-                            additionalProperties:
-                              type: string
-                            description: KubeReserved contains resources reserved
-                              for Kubernetes system components.
-                            type: object
-                            x-kubernetes-validations:
-                            - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
-                              rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage'
-                                || x=='pid')
-                            - message: kubeReserved value cannot be a negative resource
-                                quantity
-                              rule: self.all(x, !self[x].startsWith('-'))
-                          maxPods:
-                            description: |-
-                              MaxPods is an override for the maximum number of pods that can run on
-                              a worker node instance.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                          podsPerCore:
-                            description: |-
-                              PodsPerCore is an override for the number of pods that can run on a worker node
-                              instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
-                              MaxPods is a lower value, that value will be used.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                          systemReserved:
-                            additionalProperties:
-                              type: string
-                            description: SystemReserved contains resources reserved
-                              for OS system daemons and kernel memory.
-                            type: object
-                            x-kubernetes-validations:
-                            - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
-                              rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage'
-                                || x=='pid')
-                            - message: systemReserved value cannot be a negative resource
-                                quantity
-                              rule: self.all(x, !self[x].startsWith('-'))
-                        type: object
-                        x-kubernetes-validations:
-                        - message: imageGCHighThresholdPercent must be greater than
-                            imageGCLowThresholdPercent
-                          rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent)
-                            ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  :
-                            true'
-                        - message: evictionSoft OwnerKey does not have a matching
-                            evictionSoftGracePeriod
-                          rule: has(self.evictionSoft) ? self.evictionSoft.all(e,
-                            (e in self.evictionSoftGracePeriod)):true
-                        - message: evictionSoftGracePeriod OwnerKey does not have
-                            a matching evictionSoft
-                          rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e,
-                            (e in self.evictionSoft)):true
-                      nodeClassRef:
-                        description: NodeClassRef is a reference to an object that
-                          defines provider specific configuration
-                        properties:
-                          apiVersion:
-                            description: API version of the referent
-                            type: string
-                          kind:
-                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                            type: string
-                          name:
-                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      requirements:
-                        description: Requirements are layered with GetLabels and applied
-                          to every node.
-                        items:
-                          description: |-
-                            A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
-                            and minValues that represent the requirement to have at least that many values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            minValues:
-                              description: |-
-                                This field is ALPHA and can be dropped or replaced at any time
-                                MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
-                              maximum: 50
-                              minimum: 1
-                              type: integer
-                            operator:
-                              description: |-
-                                Represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: |-
-                                An array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. If the operator is Gt or Lt, the values
-                                array must have a single element, which will be interpreted as an integer.
-                                This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        maxItems: 100
-                        type: array
-                        x-kubernetes-validations:
-                        - message: requirements with operator 'In' must have a value
-                            defined
-                          rule: 'self.all(x, x.operator == ''In'' ? x.values.size()
-                            != 0 : true)'
-                        - message: requirements operator 'Gt' or 'Lt' must have a
-                            single positive integer value
-                          rule: 'self.all(x, (x.operator == ''Gt'' || x.operator ==
-                            ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >=
-                            0) : true)'
-                        - message: requirements with 'minValues' must have at least
-                            that many values specified in the 'values' field
-                          rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues))
-                            ? x.values.size() >= x.minValues : true)'
-                      resources:
-                        description: Resources models the resource requirements for
-                          the NodeClaim to launch
-                        properties:
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: Requests describes the minimum required resources
-                              for the NodeClaim to launch
-                            type: object
-                        type: object
-                      startupTaints:
-                        description: |-
-                          StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
-                          within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
-                          daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
-                          purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
-                        items:
-                          description: |-
-                            The node this Taint is attached to has the "effect" on
-                            any pod that does not tolerate the Taint.
-                          properties:
-                            effect:
-                              description: |-
-                                Required. The effect of the taint on pods
-                                that do not tolerate the taint.
-                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                              type: string
-                            key:
-                              description: Required. The taint key to be applied to
-                                a node.
-                              type: string
-                            timeAdded:
-                              description: |-
-                                TimeAdded represents the time at which the taint was added.
-                                It is only written for NoExecute taints.
-                              format: date-time
-                              type: string
-                            value:
-                              description: The taint value corresponding to the taint
-                                key.
-                              type: string
-                          required:
-                          - effect
-                          - key
-                          type: object
-                        type: array
-                      taints:
-                        description: Taints will be applied to the NodeClaim's node.
-                        items:
-                          description: |-
-                            The node this Taint is attached to has the "effect" on
-                            any pod that does not tolerate the Taint.
-                          properties:
-                            effect:
-                              description: |-
-                                Required. The effect of the taint on pods
-                                that do not tolerate the taint.
-                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                              type: string
-                            key:
-                              description: Required. The taint key to be applied to
-                                a node.
-                              type: string
-                            timeAdded:
-                              description: |-
-                                TimeAdded represents the time at which the taint was added.
-                                It is only written for NoExecute taints.
-                              format: date-time
-                              type: string
-                            value:
-                              description: The taint value corresponding to the taint
-                                key.
-                              type: string
-                          required:
-                          - effect
-                          - key
-                          type: object
-                        type: array
-                    required:
-                    - nodeClassRef
-                    - requirements
-                    type: object
-                required:
-                - spec
-                type: object
-              weight:
-                description: |-
-                  Weight is the priority given to the nodepool during scheduling. A higher
-                  numerical weight indicates that this nodepool will be ordered
-                  ahead of other nodepools with lower weights. A nodepool with no weight
-                  will be treated as if it is a nodepool with a weight of 0.
-                format: int32
-                maximum: 100
-                minimum: 1
-                type: integer
-            required:
-            - template
-            type: object
-          status:
-            description: NodePoolStatus defines the observed state of NodePool
-            properties:
-              conditions:
-                description: Conditions contains signals for health and readiness
-                items:
-                  description: Condition aliases the upstream type and adds additional
-                    helper methods
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              resources:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Resources is the list of resources that have been provisioned.
-                type: object
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
     subresources:
       status: {}


### PR DESCRIPTION
Fixes #N/A

**Description**
Ran `make generate`.
The crds are out of date with our version of upstream karpenter core.
I also had to change a line in the `generate` make target, because otherwise it autogenerated a `test` crd.

In the future, we should run `make generate` whenever bumping Karpenter.

I want to followup this PR with one that allows the helm chart to copy over these autogenerated crds.

Note that `v1beta` versions got removed from the `NodePool` and `NodeClaim` crds.

**How was this change tested?**
Tested by running manually with new crds applied and this no longer gets logged:
```
{"level":"INFO","time":"2025-10-31T19:27:14.289Z","logger":"controller","message":"unknown field \"status.nodeClassObservedGeneration\"","controller":"nodepool.registrationhealth","controllerGroup":"karpenter.sh","controllerKind":"NodePool","NodePool":{"name":"default"},"namespace":"","name":"default","reconcileID":"32e9e751-bb5e-4f7d-997d-690f6946ed6c"}
```
And scale-up and scale-down works as before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
