### PR TITLE
fix: update chart to specify image repo and tag

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: {{ include "karpenter.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.image.tag }}
+          image: {{ .Values.image.repo }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /karpenter-clusterapi-controller

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -6,8 +6,10 @@ fullnameOverride: ""
 replicaCount: 1
 
 image:
+  # -- Repo to use for the image
+  repo: gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller
   # -- Tag of the controller image
-  tag: karpenter-clusterapi-controller
+  tag: latest
   # -- Image pull policy of the controller image
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description** This uses the image repo specified in cloudbuild.yaml and the Makefile for the chart's Deployment.

**How was this change tested?**: I installed the chart as-is in this branch on a cluster from `charts/karpenter`: 
```
helm upgrade --install --namespace karpenter --create-namespace karpenter .
```
The image still doesn't exist yet so it still goes into `ImagePullBackOff` for now:
```
  Normal   Scheduled  8s    default-scheduler  Successfully assigned karpenter/karpenter-6d759877bf-mkxfs to test-cluster-79djt-xh4pr
  Normal   Pulling    8s    kubelet            Pulling image "gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller:latest"
  Warning  Failed     8s    kubelet            Failed to pull image "gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller:latest": failed to pull and unpack image "gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller:latest": failed to resolve reference "gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller:latest": unexpected status from HEAD request to https://gcr.io/v2/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller/manifests/latest: 400 Bad Request
  Warning  Failed     8s    kubelet            Error: ErrImagePull
  Normal   BackOff    7s    kubelet            Back-off pulling image "gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller:latest"
  Warning  Failed     7s    kubelet            Error: ImagePullBackOff
```
Before this change it was trying to use Dockerhub:
```
  Warning  Failed     2m7s (x4 over 3m29s)  kubelet            Failed to pull image "karpenter-clusterapi-controller": failed to pull and unpack image "docker.io/library/karpenter-clusterapi-controller:latest": failed to resolve reference "docker.io/library/karpenter-clusterapi-controller:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
