### PR TITLE
chore(ci): add e2e github action

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,30 @@
+name: e2e
+on:
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  e2e:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    name: e2e
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
+      with:
+        go-version: '1.25'
+    - uses: helm/kind-action@v1.13.0
+      with:
+        install_only: true
+    - uses: ko-build/setup-ko@v0.9
+    - name: Setup CAPK management and tenant clusters
+      shell: bash
+      run: |
+        ./test/hack/e2e.sh
+      env:
+        KIND_CLUSTER_IMAGE: kindest/node:v1.32.8
+    - name: cleanup 
+      shell: bash
+      run: | 
+        kind delete cluster --name km-cp
+        kind delete cluster

--- a/test/hack/e2e.sh
+++ b/test/hack/e2e.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CAPK_VERSION=v0.10.0
+CAPI_VERSION=release-1.10
+CALICO_VERSION=v3.24.1
+DEFAULT_KIND_IMAGE=kindest/node:v1.32.8
+
+WORKSPACE="${WORKSPACE:-$(pwd)}"
+mkdir -p "$WORKSPACE"
+cd "$WORKSPACE"
+
+if [[ ! -d cluster-api-provider-kubemark ]]; then
+  git clone https://github.com/kubernetes-sigs/cluster-api-provider-kubemark.git -b "$CAPK_VERSION" --single-branch
+fi
+
+CAPK_HACK="$WORKSPACE/cluster-api-provider-kubemark/hack"
+
+# TODO(maxcao13): kubemark v0.10.0 is using golang.org/x/tools@v0.24.0 which is incompatible with go1.25
+# https://github.com/golang/go/issues/7446
+go mod -C "$CAPK_HACK/tools" edit -replace=golang.org/x/tools=golang.org/x/tools@v0.24.1
+go mod -C "$CAPK_HACK/tools" tidy && go mod -C "$CAPK_HACK/tools" download
+
+if [[ ! -d cluster-api ]]; then
+  git clone https://github.com/kubernetes-sigs/cluster-api.git -b "$CAPI_VERSION" --single-branch
+fi
+
+export KIND_CLUSTER_IMAGE="${KIND_CLUSTER_IMAGE:-$DEFAULT_KIND_IMAGE}"
+export CAPI_PATH="$WORKSPACE/cluster-api"
+
+# don't run the entire suite with make -C cluster-api-provider-kubemark/hack/tests test-e2e
+# we want to create our own machine deployments and scale them up with karpenter
+ 
+# kubemark script doesn't delete the tenant cluster, if it exists
+kind delete cluster --name km-cp
+
+make -C "$CAPK_HACK/tests" .start-kind-cluster
+make -C "$CAPK_HACK/tests" .install-cert-manager
+make -C "$CAPK_HACK/tests" .capi-build-clusterctl
+make -C "$CAPK_HACK/tests" .generate-clusterctl-config
+make -C "$CAPK_HACK/tests" .generate-manifests
+make -C "$CAPK_HACK/tests" .docker-build
+make -C "$CAPK_HACK/tests" .create-local-repository
+make -C "$CAPK_HACK/tests" .config-local-repository
+make -C "$CAPK_HACK/tests" .deploy-cluster-api
+make -C "$CAPK_HACK/tests" .create-tenant-cluster-control-plane
+# make -C "$CAPK_HACK/tests" .create-tenant-cluster-hollow-nodes # purposefully ignoring
+make -C "$CAPK_HACK/tests" .generate-tenant-cluster-kubeconfig
+make -C "$CAPK_HACK/tests" .tenant-cluster-info
+
+TENANT_KUBECTL="kubectl --kubeconfig /tmp/km.kubeconfig"
+
+# apply capi workload resources
+kubectl apply -f "$WORKSPACE"/test/resources/kubemark-machine-deployment.yaml
+
+# apply calico for CNI
+$TENANT_KUBECTL apply -f https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/manifests/calico.yaml
+
+# we have to manually edit the management kubeconfig for karpenter to use from within the tenant cluster
+# use Kind control-plane container's IP as server
+# drop CA and skip TLS verify (Kind cert SAN doesn't match IP)
+kind get kubeconfig > /tmp/mgmt.kubeconfig
+KIND_CP_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)
+sed -i "s|server: .*|server: https://${KIND_CP_IP}:6443|g" /tmp/mgmt.kubeconfig
+sed -i '/certificate-authority-data:/d' /tmp/mgmt.kubeconfig
+sed -i '/server: https:\/\//a\    insecure-skip-tls-verify: true' /tmp/mgmt.kubeconfig
+$TENANT_KUBECTL create configmap mgmt-kubeconfig \
+  --from-file=kubeconfig=/tmp/mgmt.kubeconfig -n kube-system
+
+# apply karpenter deployment manifests and CRDs
+# deployment should have the mounted configmap
+KIND_CLUSTER_NAME=km-cp KWOK_REPO=kind.local KUBECONFIG=/tmp/km.kubeconfig make apply
+
+$TENANT_KUBECTL wait -n kube-system deployment karpenter --for condition=Available --timeout=2m
+
+# TODO(maxcao13): below is a temporary validation test that karpenter works, we should remove this when we have real tests
+
+# apply karpenter workload manifests
+$TENANT_KUBECTL apply -f "$WORKSPACE"/test/resources/default_clusterapinodeclass.yaml
+$TENANT_KUBECTL apply -f "$WORKSPACE"/test/resources/default_nodepool.yaml
+$TENANT_KUBECTL apply -f "$WORKSPACE"/test/resources/sample_deployment.yaml
+
+# scale up the deployment
+$TENANT_KUBECTL scale deployment scale-up --replicas=3
+
+printf "\nWaiting for 20 seconds for karpenter to scale up...\n"
+sleep 20
+
+$TENANT_KUBECTL get pods,nodeclaims,nodes -o wide
+
+# scale down the deployment
+$TENANT_KUBECTL scale deployment scale-up --replicas=0
+
+printf "\nWaiting for 60 seconds for karpenter to scale down...\n"
+sleep 60
+
+$TENANT_KUBECTL get pods,nodeclaims,nodes -o wide
+
+printf "\nTest completed successfully!"

--- a/test/resources/default_clusterapinodeclass.yaml
+++ b/test/resources/default_clusterapinodeclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: karpenter.cluster.x-k8s.io/v1alpha1
+kind: ClusterAPINodeClass
+metadata:
+  name: default
+spec: {}

--- a/test/resources/default_nodepool.yaml
+++ b/test/resources/default_nodepool.yaml
@@ -1,0 +1,21 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: "kubernetes.io/arch"
+          operator: In
+          values: ["amd64"]
+        - key: "node.cluster.x-k8s.io"
+          operator: In
+          values: ["workload-target"]
+        - key: "karpenter.sh/capacity-type"
+          operator: In
+          values: ["on-demand"]
+      nodeClassRef:
+        group: karpenter.cluster.x-k8s.io
+        kind: ClusterAPINodeClass
+        name: default

--- a/test/resources/karpenter-install.yaml
+++ b/test/resources/karpenter-install.yaml
@@ -1,0 +1,172 @@
+# TODO(maxcao13): deprecate in favor of helm chart install
+# this manifest is intended to setup for smoketesting with kubemark CAPI and the e2e tests
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karpenter
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter
+  labels:
+    app.kubernetes.io/name: karpenter
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools", "nodepools/status", "nodeclaims", "nodeclaims/status"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["karpenter.sh"]
+    resources: ["nodepools/finalizers", "nodeclaims/finalizers"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["karpenter.cluster.x-k8s.io"]
+    resources: ["clusterapinodeclasses", "clusterapinodeclasses/status"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: ["machines", "machinedeployments"]
+    verbs: ["get", "watch", "list", "update"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "persistentvolumes", "persistentvolumeclaims", "replicationcontrollers", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes", "volumeattachments"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karpenter
+  labels:
+    app.kubernetes.io/name: karpenter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: karpenter
+subjects:
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karpenter
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karpenter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karpenter
+    spec:
+      serviceAccountName: karpenter
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: karpenter
+          image: REPLACE_IMAGE # this is replaced when we do 'make apply'
+          imagePullPolicy: Never
+          command:
+            - /ko-app/controller
+          args:
+            - --leader-election-namespace=kube-system
+            - --cluster-api-kubeconfig=/etc/karpenter/mgmt-kubeconfig
+          env:
+            - name: SYSTEM_NAMESPACE
+              value: kube-system
+            - name: LOG_LEVEL
+              value: "debug"
+            - name: HEALTH_PROBE_PORT
+              value: "8081"
+            - name: METRICS_PORT
+              value: "8080"
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: http-health
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-health
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http-health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: mgmt-kubeconfig
+              mountPath: /etc/karpenter
+      # note this requires a config map to have been created that contains the management
+      # cluster kubeconfig contents that can be referenced from the tenant cluster
+      volumes:
+        - name: mgmt-kubeconfig
+          configMap:
+            name: mgmt-kubeconfig
+            items:
+              - key: kubeconfig
+                path: mgmt-kubeconfig
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists

--- a/test/resources/kubemark-machine-deployment.yaml
+++ b/test/resources/kubemark-machine-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  annotations:
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "10"
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
+    capacity.cluster-autoscaler.kubernetes.io/memory: "4G"
+    capacity.cluster-autoscaler.kubernetes.io/cpu: "2"
+    capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk: "100Gi"
+    capacity.cluster-autoscaler.kubernetes.io/maxPods: "110"
+    capacity.cluster-autoscaler.kubernetes.io/labels: kubernetes.io/arch=amd64,karpenter.sh/capacity-type=on-demand,node.kubernetes.io/instance-type=kubemark-0,topology.kubernetes.io/zone=us-east-1a
+    cluster.x-k8s.io/machine-current-price: "0.50" # not supported yet
+  labels:
+    node.cluster.x-k8s.io/karpenter-member: ""
+  name: km-wl-kubemark-md-0
+  namespace: default
+spec:
+  clusterName: km-cp
+  replicas: 0
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: km-cp
+      cluster.x-k8s.io/deployment-name: km-wl-kubemark-md-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: km-cp
+        cluster.x-k8s.io/deployment-name: km-wl-kubemark-md-0
+        node.cluster.x-k8s.io: workload-target
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: km-wl-kubemark-md-0
+      clusterName: km-cp
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: KubemarkMachineTemplate
+        name: km-wl-kubemark-md-0
+      version: v1.32.8
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: KubemarkMachineTemplate
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: km-cp
+  name: km-wl-kubemark-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      extraMounts:
+        - name: containerd-sock
+          containerPath: /run/containerd/containerd.sock
+          hostPath: /run/containerd/containerd.sock
+          type: Socket
+      # these kubemarkOptions are required for karpenter
+      kubemarkOptions:
+        extendedResources:
+          cpu: 2
+          memory: 4Gi
+        registerWithTaints:
+          - key: karpenter.sh/unregistered
+            effect: NoExecute
+        nodeLabels:
+          karpenter.sh/capacity-type: on-demand
+          node.kubernetes.io/instance-type: kubemark-0
+          topology.kubernetes.io/zone: us-east-1a
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: km-wl-kubemark-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: ''

--- a/test/resources/sample_deployment.yaml
+++ b/test/resources/sample_deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale-up
+  labels:
+    app: scale-up
+  namespace: default
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: scale-up
+  template:
+    metadata:
+      labels:
+        app: scale-up
+    spec:
+      nodeSelector:
+        karpenter.sh/nodepool: default
+      affinity:
+      # make sure pods run on different nodes
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: scale-up
+      containers:
+        - name: busybox
+          image: quay.io/elmiko/busybox
+          resources:
+            requests:
+              memory: "200M" 
+              cpu: "100m"
+          command:
+            - /bin/sh
+            - "-c"
+            - "echo 'this should be in the logs' && sleep 86400"
+      terminationGracePeriodSeconds: 0


### PR DESCRIPTION
Related to: #67 

**Description**
This commit adds a github action which re-uses the kubemark capi e2e tests: https://github.com/kubernetes-sigs/cluster-api-provider-kubemark

I created a new e2e hack script in `./test/hack/e2e.sh` and this is generally what it does in order:
1. Clone cluster-api-provider-kubemark
2. Clone cluster-api
3. Use the cluster-api-provider-kubemark e2e tests to set up a CAPI environment with a management cluster and tenant cluster
    - I skip the `create-hollow-nodes` step here, since we want to create our own CAPI workloads that are compatible with Karpenter (i.e. have correct annotations, labels, taints, etc.)
5. Apply CAPI manifests (`KubemarkMachineTemplate`, `MachineDeployment`, etc.) to the management cluster which will be considered the "infrastructure" that Karpenter will try to provision and scale
6. Apply Karpenter deployment manifests to the tenant cluster
   - one caveat here is that the karpenter controller needs to be able to see into the CAPI cluster, so I needed to mount a kubeconfig into the tenant karpenter deployment
   - another caveat, I use `ko` to build a local karpenter capi image, and push it directly into the kind registry with `ko apply` similar to the `kubernetes-sigs/karpenter` repo does with the kwok provider. Then I have to replace the image reference in the deployment manifest before applying. I don't use helm here to do this since our helm chart is still in an alpha stage I believe.
7. Apply Karpenter workload manifests (`deployment`, `nodepool`, `capinodeclass`)
8. Scale up the deployment and scale down
    - Currently there is no actual validation, we can only simply see what nodes and nodeclaims have been created in the cluster during the test.

This will allows us to start regression testing any changes to the project, and build upon this initial e2e. A followup to this PR would be to implement the karpenter core tests into the github action as detailed in #67 

**How was this change tested?**

By using https://github.com/nektos/act

I installed act on my VM and used this command and it looked something like:
```bash
$ act push -j e2e
...lots of output
...
...
| Waiting for 20 seconds for karpenter to scale up...
| NAME                            READY   STATUS    RESTARTS   AGE   IP                NODE                              NOMINATED NODE   READINESS GATES
| pod/scale-up-58fcd75b95-bwd9f   1/1     Running   0          20s   192.168.192.168   km-wl-kubemark-md-0-hthhb-6bcwc   <none>           <none>
| pod/scale-up-58fcd75b95-p5k4d   1/1     Running   0          20s   192.168.192.168   km-wl-kubemark-md-0-hthhb-glq7v   <none>           <none>
| pod/scale-up-58fcd75b95-vglmm   1/1     Running   0          20s   192.168.192.168   km-wl-kubemark-md-0-hthhb-x7d6v   <none>           <none>
| 
| NAME                                   TYPE         CAPACITY    ZONE         NODE                              READY   AGE   IMAGEID   ID                                           NODEPOOL   NODECLASS   DRIFTED
| nodeclaim.karpenter.sh/default-f6j9d   kubemark-0   on-demand   us-east-1a   km-wl-kubemark-md-0-hthhb-x7d6v   True    19s             kubemark://km-wl-kubemark-md-0-hthhb-x7d6v   default    default     
| nodeclaim.karpenter.sh/default-sspm7   kubemark-0   on-demand   us-east-1a   km-wl-kubemark-md-0-hthhb-6bcwc   True    19s             kubemark://km-wl-kubemark-md-0-hthhb-6bcwc   default    default     
| nodeclaim.karpenter.sh/default-w8pmh   kubemark-0   on-demand   us-east-1a   km-wl-kubemark-md-0-hthhb-glq7v   True    19s             kubemark://km-wl-kubemark-md-0-hthhb-glq7v   default    default     
| 
| NAME                                   STATUS   ROLES           AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION         CONTAINER-RUNTIME
| node/km-cp-control-plane-x5wcz         Ready    control-plane   115s   v1.32.8   172.18.0.5    <none>        Debian GNU/Linux 12 (bookworm)   5.15.0-168-generic     containerd://2.1.3
| node/km-wl-kubemark-md-0-hthhb-6bcwc   Ready    <none>          16s    v1.32.8   10.244.0.14   <none>        Debian GNU/Linux 7 (wheezy)      3.16.0-0.bpo.4-amd64   fakeRuntime://0.1.0
| node/km-wl-kubemark-md-0-hthhb-glq7v   Ready    <none>          15s    v1.32.8   10.244.0.15   <none>        Debian GNU/Linux 7 (wheezy)      3.16.0-0.bpo.4-amd64   fakeRuntime://0.1.0
| node/km-wl-kubemark-md-0-hthhb-x7d6v   Ready    <none>          16s    v1.32.8   10.244.0.13   <none>        Debian GNU/Linux 7 (wheezy)      3.16.0-0.bpo.4-amd64   fakeRuntime://0.1.0
| deployment.apps/scale-up scaled
| 
| Waiting for 60 seconds for karpenter to scale down...
| NAME                             STATUS   ROLES           AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION       CONTAINER-RUNTIME
| node/km-cp-control-plane-x5wcz   Ready    control-plane   2m55s   v1.32.8   172.18.0.5    <none>        Debian GNU/Linux 12 (bookworm)   5.15.0-168-generic   containerd://2.1.3
| 
[e2e/e2e]   ✅  Success - Main Setup CAPK management and tenant clusters [8m0.638428517s]
[e2e/e2e] ⭐ Run Main cleanup
[e2e/e2e]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/5.sh] user= workdir=
| Deleting cluster "km-cp" ...
| Deleted nodes: ["km-cp-control-plane-x5wcz" "km-cp-lb"]
| Deleting cluster "kind" ...
| Deleted nodes: ["kind-control-plane"]
[e2e/e2e]   ✅  Success - Main cleanup [2.608540508s]
[e2e/e2e] ⭐ Run Post ko-build/setup-ko@v0.9
[e2e/e2e]   🐳  docker cp src=/home/macao/.cache/act/ko-build-setup-ko@v0.9/ dst=/var/run/act/actions/ko-build-setup-ko@v0.9/
[e2e/e2e]   ✅  Success - Post ko-build/setup-ko@v0.9 [16.717911ms]
[e2e/e2e] ⭐ Run Post helm/kind-action@v1.13.0
[e2e/e2e]   🐳  docker exec cmd=[/opt/acttoolcache/node/24.13.0/x64/bin/node /var/run/act/actions/helm-kind-action@v1.13.0/cleanup.js] user= workdir=
| kind-registry
| Deleting cluster "chart-testing" ...
[e2e/e2e]   ✅  Success - Post helm/kind-action@v1.13.0 [530.678392ms]
[e2e/e2e] ⭐ Run Post actions/setup-go@v6
[e2e/e2e]   🐳  docker exec cmd=[/opt/acttoolcache/node/24.13.0/x64/bin/node /var/run/act/actions/actions-setup-go@v6/dist/cache-save/index.js] user= workdir=
| [command]/opt/hostedtoolcache/go/1.25.7/x64/bin/go env GOMODCACHE
| [command]/opt/hostedtoolcache/go/1.25.7/x64/bin/go env GOCACHE
| /root/go/pkg/mod
| /root/.cache/go-build
| [command]/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/macao/karpenter-provider-cluster-api --files-from manifest.txt --use-compress-program zstdmt
| Cache Size: ~1034 MB (1083749890 B)
| Cache saved successfully
| Cache saved with the key: setup-go-Linux-x64-ubuntu20-go-1.25.7-c96a65f2d39f7e87fc87a2b7e153462c12a1e595e916986f7010568b7db0374a
[e2e/e2e]   ✅  Success - Post actions/setup-go@v6 [17.085070997s]
[e2e/e2e] ⭐ Run Complete job
[e2e/e2e] Cleaning up container for job e2e
[e2e/e2e]   ✅  Success - Complete job
[e2e/e2e] 🏁  Job succeeded

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
