### PR TITLE
fix: incorrect machine selection during create

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -253,7 +253,7 @@ func (c *CloudProvider) List(ctx context.Context) ([]*karpv1.NodeClaim, error) {
 			},
 		},
 	}
-	machines, err := c.machineProvider.List(ctx, &selector)
+	machines, err := c.machineProvider.List(ctx, "", &selector)
 	if err != nil {
 		return nil, fmt.Errorf("listing machines, %w", err)
 	}
@@ -482,7 +482,7 @@ func (c *CloudProvider) pollForUnclaimedMachineInMachineDeploymentWithTimeout(ct
 	}
 
 	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		machineList, err := c.machineProvider.List(ctx, selector)
+		machineList, err := c.machineProvider.List(ctx, machineDeployment.Namespace, selector)
 		if err != nil {
 			// this might need to ignore the error for the sake of the timeout
 			return false, fmt.Errorf("error listing unclaimed Machines for MachineDeployment %q: %w", machineDeployment.Name, err)

--- a/pkg/providers/machine/machine.go
+++ b/pkg/providers/machine/machine.go
@@ -29,7 +29,7 @@ import (
 type Provider interface {
 	Get(context.Context, string, string) (*capiv1beta1.Machine, error)
 	GetByProviderID(context.Context, string) (*capiv1beta1.Machine, error)
-	List(context.Context, *metav1.LabelSelector) ([]*capiv1beta1.Machine, error)
+	List(context.Context, string, *metav1.LabelSelector) ([]*capiv1beta1.Machine, error)
 	IsDeleting(*capiv1beta1.Machine) bool
 	AddDeleteAnnotation(context.Context, *capiv1beta1.Machine) error
 	RemoveDeleteAnnotation(context.Context, *capiv1beta1.Machine) error
@@ -74,10 +74,15 @@ func (p *DefaultProvider) GetByProviderID(ctx context.Context, providerID string
 	return nil, nil
 }
 
-func (p *DefaultProvider) List(ctx context.Context, selector *metav1.LabelSelector) ([]*capiv1beta1.Machine, error) {
+func (p *DefaultProvider) List(ctx context.Context, namespace string, selector *metav1.LabelSelector) ([]*capiv1beta1.Machine, error) {
 	machines := []*capiv1beta1.Machine{}
 
 	listOptions := []client.ListOption{}
+
+	if namespace != "" {
+		listOptions = append(listOptions, client.InNamespace(namespace))
+	}
+
 	if selector != nil {
 		sm, err := metav1.LabelSelectorAsSelector(selector)
 		if err != nil {

--- a/pkg/providers/machine/machine_test.go
+++ b/pkg/providers/machine/machine_test.go
@@ -48,12 +48,12 @@ var _ = Describe("Machine DefaultProvider.IsDeleting method", func() {
 	})
 
 	It("return false when Machine deletion timestamp is zero", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		Expect(provider.IsDeleting(machine)).To(BeFalse())
 	})
 
 	It("return true when Machine deletion timestamp is not zero", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		timestamp := metav1.NewTime(time.Now())
 		machine.SetDeletionTimestamp(&timestamp)
 		Expect(provider.IsDeleting(machine)).To(BeTrue())
@@ -83,7 +83,7 @@ var _ = Describe("Machine DefaultProvider.Get method", func() {
 	})
 
 	It("returns nil when there is no Machine with the requested provider ID", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
 		machine, err := provider.GetByProviderID(context.Background(), "clusterapi://the-wrong-provider-id")
@@ -92,9 +92,9 @@ var _ = Describe("Machine DefaultProvider.Get method", func() {
 	})
 
 	It("returns the expected Machine when it is present in the API", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
-		machine = newMachine("karpenter-2", "karpenter-cluster", true)
+		machine = newMachine("karpenter-2", testNamespace, "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
 		providerID := *machine.Spec.ProviderID
@@ -104,9 +104,9 @@ var _ = Describe("Machine DefaultProvider.Get method", func() {
 	})
 
 	It("returns the expected Machine when it is present in the API and not a NodePool member", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
-		machine = newMachine("karpenter-2", "karpenter-cluster", false)
+		machine = newMachine("karpenter-2", testNamespace, "karpenter-cluster", false)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
 		providerID := *machine.Spec.ProviderID
@@ -133,48 +133,75 @@ var _ = Describe("Machine DefaultProvider.List method", func() {
 	})
 
 	AfterEach(func() {
-		Expect(cl.DeleteAllOf(context.Background(), &capiv1beta1.Machine{}, client.InNamespace(testNamespace))).To(Succeed())
-		Eventually(func() client.ObjectList {
-			machineList := &capiv1beta1.MachineList{}
-			Expect(cl.List(context.Background(), machineList, client.InNamespace(testNamespace))).To(Succeed())
-			return machineList
-		}).Should(HaveField("Items", HaveLen(0)))
+		for _, ns := range []string{testNamespace, otherTestNamespace} {
+			Expect(cl.DeleteAllOf(context.Background(), &capiv1beta1.Machine{}, client.InNamespace(ns))).To(Succeed())
+			Eventually(func() client.ObjectList {
+				machineList := &capiv1beta1.MachineList{}
+				Expect(cl.List(context.Background(), machineList, client.InNamespace(ns))).To(Succeed())
+				return machineList
+			}).Should(HaveField("Items", HaveLen(0)))
+		}
 	})
 
 	It("returns an empty list when no Machines are present in API", func() {
-		machines, err := provider.List(context.Background(), &NodePoolMemberLabelSelector)
+		machines, err := provider.List(context.Background(), testNamespace, &NodePoolMemberLabelSelector)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machines).To(HaveLen(0))
 	})
 
 	It("returns a list of correct length when there are only karpenter member Machines", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
-		machines, err := provider.List(context.Background(), &NodePoolMemberLabelSelector)
+		machines, err := provider.List(context.Background(), testNamespace, &NodePoolMemberLabelSelector)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machines).To(HaveLen(1))
 	})
 
 	It("returns a list of correct length when there are mixed member Machines", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
-		machine = newMachine("clusterapi-1", "workload-cluster", false)
+		machine = newMachine("clusterapi-1", testNamespace, "workload-cluster", false)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
-		machines, err := provider.List(context.Background(), &NodePoolMemberLabelSelector)
+		machines, err := provider.List(context.Background(), testNamespace, &NodePoolMemberLabelSelector)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machines).To(HaveLen(1))
 	})
 
 	It("returns an empty list when no member Machines are present", func() {
-		machine := newMachine("clusterapi-1", "workload-cluster", false)
+		machine := newMachine("clusterapi-1", testNamespace, "workload-cluster", false)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
-		machines, err := provider.List(context.Background(), &NodePoolMemberLabelSelector)
+		machines, err := provider.List(context.Background(), testNamespace, &NodePoolMemberLabelSelector)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machines).To(HaveLen(0))
+	})
+
+	It("returns only Machines from the specified namespace", func() {
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
+		Expect(cl.Create(context.Background(), machine)).To(Succeed())
+
+		machine = newMachine("karpenter-1", otherTestNamespace, "karpenter-cluster", true)
+		Expect(cl.Create(context.Background(), machine)).To(Succeed())
+
+		machines, err := provider.List(context.Background(), testNamespace, &NodePoolMemberLabelSelector)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(machines).To(HaveLen(1))
+		Expect(machines[0].Namespace).To(Equal(testNamespace))
+	})
+
+	It("returns Machines from all namespaces when namespace is empty", func() {
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
+		Expect(cl.Create(context.Background(), machine)).To(Succeed())
+
+		machine = newMachine("karpenter-1", otherTestNamespace, "karpenter-cluster", true)
+		Expect(cl.Create(context.Background(), machine)).To(Succeed())
+
+		machines, err := provider.List(context.Background(), "", &NodePoolMemberLabelSelector)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(machines).To(HaveLen(2))
 	})
 })
 
@@ -200,13 +227,13 @@ var _ = Describe("Machine DefaultProvider.AddDeleteAnnotation method", func() {
 	})
 
 	It("returns an error when the Machine does not exist", func() {
-		machine := newMachine("non-existent", "fake-cluster", false)
+		machine := newMachine("non-existent", testNamespace, "fake-cluster", false)
 		err := provider.AddDeleteAnnotation(context.Background(), machine)
 		Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("unable to add deletion annotation to Machine %q", machine.Name))))
 	})
 
 	It("adds the deletion annotation", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		Expect(cl.Create(context.Background(), machine)).To(Succeed())
 
 		err := provider.AddDeleteAnnotation(context.Background(), machine)
@@ -242,7 +269,7 @@ var _ = Describe("Machine DefaultProvider.RemoveDeleteAnnotation method", func()
 	})
 
 	It("returns an error when the Machine does not exist", func() {
-		machine := newMachine("non-existent", "fake-cluster", false)
+		machine := newMachine("non-existent", testNamespace, "fake-cluster", false)
 		annotations := map[string]string{
 			capiv1beta1.DeleteMachineAnnotation: time.Now().String(),
 		}
@@ -252,7 +279,7 @@ var _ = Describe("Machine DefaultProvider.RemoveDeleteAnnotation method", func()
 	})
 
 	It("removes the deletion annotation", func() {
-		machine := newMachine("karpenter-1", "karpenter-cluster", true)
+		machine := newMachine("karpenter-1", testNamespace, "karpenter-cluster", true)
 		annotations := map[string]string{
 			capiv1beta1.DeleteMachineAnnotation: time.Now().String(),
 		}
@@ -270,10 +297,10 @@ var _ = Describe("Machine DefaultProvider.RemoveDeleteAnnotation method", func()
 	})
 })
 
-func newMachine(machineName string, clusterName string, karpenterMember bool) *capiv1beta1.Machine {
+func newMachine(machineName string, machineNamespace string, clusterName string, karpenterMember bool) *capiv1beta1.Machine {
 	machine := &capiv1beta1.Machine{}
 	machine.SetName(machineName)
-	machine.SetNamespace(testNamespace)
+	machine.SetNamespace(machineNamespace)
 	if karpenterMember {
 		labels := map[string]string{}
 		labels[providers.NodePoolMemberLabel] = ""

--- a/pkg/providers/machine/suite_test.go
+++ b/pkg/providers/machine/suite_test.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	testNamespace = "karpenter-cluster-api"
+	testNamespace      = "karpenter-cluster-api"
+	otherTestNamespace = "other-namespace"
 )
 
 func init() {
@@ -77,6 +78,10 @@ var _ = BeforeSuite(func() {
 	namespace := &corev1.Namespace{}
 	namespace.SetName(testNamespace)
 	Expect(cl.Create(context.Background(), namespace)).To(Succeed())
+
+	otherNamespace := &corev1.Namespace{}
+	otherNamespace.SetName(otherTestNamespace)
+	Expect(cl.Create(context.Background(), otherNamespace)).To(Succeed())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
When MachineDeployments with the same name exist in multiple namespaces, Karpenter may select a machine belonging to a different MachineDeployment than expected.

This patch fixes this by scoping machine listing to the namespace of the target MachineDeployment to prevent cross-namespace machine selection.

Fixes #74 
