### PR TITLE
feat(batcher): add batching for CloudProvider Create and Delete

### DIFF
--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package batcher implements a generic time-windowed batching library that
+// coalesces concurrent requests into a single bulk operation, reducing API
+// call volume and write contention on shared Kubernetes resources.
+//
+// The core [Batcher] type collects Add calls during an idle/max timeout
+// window, groups them by a caller-supplied hash, and dispatches each group to
+// a [BatchExecutor]. Callers block on Add until their result is available.
+//
+// Architecture adapted from github.com/aws/karpenter-provider-aws/pkg/batcher.
+package batcher
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Options[T any, U any] struct {
+	Name          string
+	IdleTimeout   time.Duration
+	MaxTimeout    time.Duration
+	RequestHasher RequestHasher[T]
+	BatchExecutor BatchExecutor[T, U]
+}
+
+type Result[U any] struct {
+	Output *U
+	Err    error
+}
+
+type request[T any, U any] struct {
+	ctx       context.Context
+	hash      uint64
+	input     *T
+	requestor chan Result[U]
+}
+
+// Batcher coalesces Add calls into time-windowed batches and dispatches
+// them to a BatchExecutor.  Each caller blocks on Add until its result
+// is available.
+type Batcher[T any, U any] struct {
+	ctx     context.Context
+	options Options[T, U]
+
+	mu       sync.Mutex
+	requests map[uint64][]*request[T, U]
+	trigger  chan struct{}
+}
+
+// BatchExecutor executes a batch of inputs and returns one Result per input,
+// in the same order.
+type BatchExecutor[T any, U any] func(ctx context.Context, inputs []*T) []Result[U]
+
+// RequestHasher returns a bucket key for a given input so that requests
+// targeting different resources can be batched separately.
+type RequestHasher[T any] func(ctx context.Context, input *T) uint64
+
+func NewBatcher[T any, U any](ctx context.Context, options Options[T, U]) *Batcher[T, U] {
+	b := &Batcher[T, U]{
+		ctx:      ctx,
+		options:  options,
+		requests: map[uint64][]*request[T, U]{},
+		trigger:  make(chan struct{}, 1),
+	}
+	go b.run()
+	return b
+}
+
+// Add submits an input to the batcher and blocks until the batch executes.
+func (b *Batcher[T, U]) Add(ctx context.Context, input *T) Result[U] {
+	req := &request[T, U]{
+		ctx:       ctx,
+		hash:      b.options.RequestHasher(ctx, input),
+		input:     input,
+		requestor: make(chan Result[U], 1),
+	}
+	b.mu.Lock()
+	b.requests[req.hash] = append(b.requests[req.hash], req)
+	b.mu.Unlock()
+
+	// Non-blocking send: if trigger is already pending, this is a no-op.
+	select {
+	case b.trigger <- struct{}{}:
+	default:
+	}
+
+	select {
+	case result := <-req.requestor:
+		return result
+	case <-ctx.Done():
+		return Result[U]{Err: ctx.Err()}
+	}
+}
+
+// BatchKeyer is implemented by input types that know their own batch key.
+type BatchKeyer interface {
+	BatchKey() string
+}
+
+// BatchKeyHasher hashes inputs that implement BatchKeyer.
+func BatchKeyHasher[T BatchKeyer](_ context.Context, input *T) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte((*input).BatchKey()))
+	return h.Sum64()
+}
+
+func (b *Batcher[T, U]) run() {
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-b.trigger:
+		}
+
+		b.waitForIdle()
+
+		b.mu.Lock()
+		buckets := b.requests
+		b.requests = map[uint64][]*request[T, U]{}
+		b.mu.Unlock()
+
+		for _, reqs := range buckets {
+			go b.runBatch(reqs)
+		}
+	}
+}
+
+func (b *Batcher[T, U]) waitForIdle() {
+	maxTimer := time.NewTimer(b.options.MaxTimeout)
+	defer maxTimer.Stop()
+	idleTimer := time.NewTimer(b.options.IdleTimeout)
+	defer idleTimer.Stop()
+
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-b.trigger:
+			if !idleTimer.Stop() {
+				<-idleTimer.C
+			}
+			idleTimer.Reset(b.options.IdleTimeout)
+		case <-maxTimer.C:
+			return
+		case <-idleTimer.C:
+			return
+		}
+	}
+}
+
+func (b *Batcher[T, U]) runBatch(reqs []*request[T, U]) {
+	inputs := make([]*T, len(reqs))
+	for i, r := range reqs {
+		inputs[i] = r.input
+	}
+
+	// TODO(maxcao13): Karpenter AWS emits batching metrics for observability. We can consider doing this in the future, but for now, just log.
+	log.FromContext(reqs[0].ctx).V(1).Info("executing batch", "batcher", b.options.Name, "requests", len(reqs))
+	results := b.options.BatchExecutor(reqs[0].ctx, inputs)
+
+	for i, r := range results {
+		if i < len(reqs) {
+			reqs[i].requestor <- r
+		}
+	}
+	for i := len(results); i < len(reqs); i++ {
+		reqs[i].requestor <- Result[U]{Err: fmt.Errorf("batch executor returned too few results")}
+	}
+}

--- a/pkg/batcher/create.go
+++ b/pkg/batcher/create.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batcher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers/machine"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers/machinedeployment"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+// CreateInput is the input to a single create request within a batch.
+type CreateInput struct {
+	NodeClaimName         string
+	MachineDeploymentName string
+	MachineDeploymentNS   string
+}
+
+func (c CreateInput) BatchKey() string {
+	return c.MachineDeploymentNS + "/" + c.MachineDeploymentName
+}
+
+// CreateOutput is the result of a successfully bound Machine.
+type CreateOutput struct {
+	MachineDeployment *capiv1beta1.MachineDeployment
+	Machine           *capiv1beta1.Machine
+}
+
+// CreateBatcher coalesces concurrent CloudProvider.Create calls targeting the
+// same MachineDeployment into a single replica increment + Machine poll cycle.
+type CreateBatcher struct {
+	batcher *Batcher[CreateInput, CreateOutput]
+}
+
+func NewCreateBatcher(
+	ctx context.Context,
+	kubeClient client.Client,
+	machineProvider machine.Provider,
+	mdProvider machinedeployment.Provider,
+	mdLock *MDLockManager,
+) *CreateBatcher {
+	options := Options[CreateInput, CreateOutput]{
+		Name:          "create_machine",
+		IdleTimeout:   100 * time.Millisecond,
+		MaxTimeout:    1 * time.Second,
+		RequestHasher: BatchKeyHasher[CreateInput],
+		BatchExecutor: execCreateBatch(kubeClient, machineProvider, mdProvider, mdLock),
+	}
+	return &CreateBatcher{batcher: NewBatcher(ctx, options)}
+}
+
+func (b *CreateBatcher) Add(ctx context.Context, input *CreateInput) Result[CreateOutput] {
+	return b.batcher.Add(ctx, input)
+}
+
+// execCreateBatch returns a BatchExecutor that provisions Machines for a set
+// of NodeClaims targeting the same MachineDeployment. The algorithm is:
+//
+//  1. Lock the MachineDeployment and count existing unclaimed Machines (those
+//     without the NodePoolMemberLabel). We only increment spec.replicas by the
+//     deficit (requested − unclaimed) so that leftover Machines from a previous
+//     batch are reused instead of leaked. This eliminates the need for an
+//     explicit rollback of replicas on partial failure.
+//  2. Poll for N unclaimed Machines to appear. This runs unlocked and can take
+//     up to 30 seconds while CAPI's MachineSet controller creates them.
+//  3. Bind each Machine to its corresponding NodeClaim in parallel by labeling
+//     the Machine as claimed and annotating the NodeClaim with the Machine
+//     reference.
+//
+// Requests that cannot be fulfilled (e.g. poll timeout, binding failure) are
+// returned with an error so the lifecycle controller can re-reconcile them.
+// Because we count unclaimed Machines on every batch, retries are cheap — we
+// won't increment replicas for Machines that already exist.
+//
+// A subsequent batch can claim Machines that a previous batch created but has
+// not yet bound (they are still unclaimed during the poll window). This is
+// safe because the earlier batch's unfulfilled requests will error out, the
+// lifecycle controller will re-reconcile them into a future batch, and that
+// batch will count the Machines the later batch already created — so replicas
+// are never over-incremented.
+//
+// Concurrent delete batches do not interfere: the replica read-modify-write
+// is serialized by MDLockManager, and the poll skips Machines that carry the
+// delete-machine annotation or a non-zero deletion timestamp.
+func execCreateBatch(
+	kubeClient client.Client,
+	machineProvider machine.Provider,
+	mdProvider machinedeployment.Provider,
+	mdLock *MDLockManager,
+) BatchExecutor[CreateInput, CreateOutput] {
+	return func(ctx context.Context, inputs []*CreateInput) []Result[CreateOutput] {
+		n := len(inputs)
+		results := make([]Result[CreateOutput], n)
+
+		if n == 0 {
+			return results
+		}
+
+		mdName := inputs[0].MachineDeploymentName
+		mdNS := inputs[0].MachineDeploymentNS
+		mdKey := mdNS + "/" + mdName
+
+		// 1) Count unclaimed Machines and increment replicas by the deficit.
+		mdLock.Lock(mdKey)
+		md, err := mdProvider.Get(ctx, mdName, mdNS)
+		if err != nil {
+			mdLock.Unlock(mdKey)
+			for i := range results {
+				results[i] = Result[CreateOutput]{Err: fmt.Errorf("unable to get MachineDeployment %q: %w", mdName, err)}
+			}
+			return results
+		}
+
+		unclaimed := countUnclaimedMachines(ctx, machineProvider, mdName, mdNS)
+		deficit := int32(n) - int32(unclaimed)
+		if deficit < 0 {
+			deficit = 0
+		}
+
+		log.FromContext(ctx).V(1).Info("create batch", "machineDeployment", mdKey, "requests", n, "unclaimed", unclaimed, "deficit", deficit)
+
+		if deficit > 0 {
+			currentReplicas := ptr.Deref(md.Spec.Replicas, 0)
+			md.Spec.Replicas = ptr.To(currentReplicas + deficit)
+			if err := mdProvider.Update(ctx, md); err != nil {
+				mdLock.Unlock(mdKey)
+				for i := range results {
+					results[i] = Result[CreateOutput]{Err: fmt.Errorf("unable to increment MachineDeployment %q replicas: %w", mdName, err)}
+				}
+				return results
+			}
+		}
+		mdLock.Unlock(mdKey)
+
+		// 2) Poll for N unclaimed Machines (unlocked; can take up to 30s).
+		machines := pollForNUnclaimedMachines(ctx, machineProvider, mdName, mdNS, n, 30*time.Second)
+
+		// 3) Bind each Machine to a NodeClaim in parallel.
+		// TODO(maxcao13): Use wg.Go when we bump go.mod to 1.25
+		var wg sync.WaitGroup
+		for i := 0; i < len(machines) && i < n; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				results[idx] = bindMachineToNodeClaim(ctx, kubeClient, machineProvider, md, machines[idx], inputs[idx].NodeClaimName)
+			}(i)
+		}
+		wg.Wait()
+
+		for i, r := range results {
+			if r.Err == nil && r.Output == nil {
+				results[i] = Result[CreateOutput]{Err: fmt.Errorf("no Machine available for NodeClaim")}
+			}
+		}
+
+		return results
+	}
+}
+
+// pollForNUnclaimedMachines lists Machines belonging to the MachineDeployment
+// that have not yet been claimed (no NodePoolMemberLabel). It polls every
+// second until count Machines are found or the timeout elapses, returning
+// whatever has been collected so far.
+func pollForNUnclaimedMachines(
+	ctx context.Context,
+	machineProvider machine.Provider,
+	mdName, mdNS string,
+	count int,
+	timeout time.Duration,
+) []*capiv1beta1.Machine {
+	selector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      providers.NodePoolMemberLabel,
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			},
+			{
+				Key:      capiv1beta1.MachineDeploymentNameLabel,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{mdName},
+			},
+		},
+	}
+
+	claimed := map[string]bool{}
+	var found []*capiv1beta1.Machine
+
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		machineList, err := machineProvider.List(ctx, mdNS, selector)
+		if err == nil {
+			for _, m := range machineList {
+				if claimed[m.Name] {
+					continue
+				}
+				if m.DeletionTimestamp != nil {
+					continue
+				}
+				if _, marked := m.GetAnnotations()[capiv1beta1.DeleteMachineAnnotation]; marked {
+					continue
+				}
+				claimed[m.Name] = true
+				found = append(found, m)
+				if len(found) >= count {
+					return found
+				}
+			}
+		}
+
+		if len(found) >= count {
+			return found
+		}
+
+		select {
+		case <-ctx.Done():
+			return found
+		case <-deadline:
+			return found
+		case <-ticker.C:
+		}
+	}
+}
+
+// countUnclaimedMachines returns the number of Machines in the
+// MachineDeployment that are not yet claimed and not pending deletion.
+func countUnclaimedMachines(
+	ctx context.Context,
+	machineProvider machine.Provider,
+	mdName, mdNS string,
+) int {
+	selector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      providers.NodePoolMemberLabel,
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			},
+			{
+				Key:      capiv1beta1.MachineDeploymentNameLabel,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{mdName},
+			},
+		},
+	}
+
+	machines, err := machineProvider.List(ctx, mdNS, selector)
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+	for _, m := range machines {
+		if m.DeletionTimestamp != nil {
+			continue
+		}
+		if _, marked := m.GetAnnotations()[capiv1beta1.DeleteMachineAnnotation]; marked {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// bindMachineToNodeClaim claims a Machine for a NodeClaim by labeling the
+// Machine with NodePoolMemberLabel and annotating the NodeClaim with the
+// Machine reference.
+func bindMachineToNodeClaim(
+	ctx context.Context,
+	kubeClient client.Client,
+	machineProvider machine.Provider,
+	md *capiv1beta1.MachineDeployment,
+	m *capiv1beta1.Machine,
+	nodeClaimName string,
+) Result[CreateOutput] {
+	var fresh *capiv1beta1.Machine
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		fresh, err = machineProvider.Get(ctx, m.Name, m.Namespace)
+		if err != nil {
+			return Result[CreateOutput]{Err: fmt.Errorf("unable to get Machine %q: %w", m.Name, err)}
+		}
+
+		labels := fresh.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[providers.NodePoolMemberLabel] = ""
+		fresh.SetLabels(labels)
+		err = machineProvider.Update(ctx, fresh)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return Result[CreateOutput]{Err: fmt.Errorf("unable to label Machine %q: %w", fresh.Name, err)}
+	}
+
+	// Annotate NodeClaim with Machine reference using a merge-patch to avoid
+	// stale-resourceVersion conflicts (the NodeClaim may have been updated by
+	// another controller while the batch was accumulating).
+	// If the NodeClaim annotation fails, we roll back the
+	// Machine label so it can be reclaimed by a future batch.
+	machineRef := fmt.Sprintf("%s/%s", fresh.Namespace, fresh.Name)
+	patchBytes := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, providers.MachineAnnotation, machineRef))
+	nc := &karpv1.NodeClaim{}
+	nc.Name = nodeClaimName
+	if err := kubeClient.Patch(ctx, nc, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
+		rollbackFresh, getErr := machineProvider.Get(ctx, fresh.Name, fresh.Namespace)
+		if getErr == nil {
+			lbls := rollbackFresh.GetLabels()
+			delete(lbls, providers.NodePoolMemberLabel)
+			rollbackFresh.SetLabels(lbls)
+			if updateErr := machineProvider.Update(ctx, rollbackFresh); updateErr != nil {
+				log.FromContext(ctx).Error(updateErr, "create batch: unable to remove member label from Machine", "machine", rollbackFresh.Name)
+			}
+		}
+		return Result[CreateOutput]{Err: fmt.Errorf("unable to annotate NodeClaim %q: %w", nodeClaimName, err)}
+	}
+
+	return Result[CreateOutput]{Output: &CreateOutput{MachineDeployment: md, Machine: fresh}}
+}

--- a/pkg/batcher/create_test.go
+++ b/pkg/batcher/create_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batcher_test
+
+import (
+	"fmt"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/batcher"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers"
+)
+
+var _ = Describe("Create Batching", func() {
+	var (
+		fakeMP  *fakeMachineProvider
+		fakeMDP *fakeMDProvider
+	)
+
+	BeforeEach(func() {
+		fakeMP = newFakeMachineProvider()
+		fakeMDP = newFakeMDProvider()
+	})
+
+	// newCreateBatcher builds a CreateBatcher backed by a fake kube client
+	// pre-seeded with the given NodeClaim names. The create batch executor
+	// patches NodeClaim objects via client.Client, so they must exist before
+	// the batch runs. The returned client can be used to verify NodeClaim
+	// annotations after the batch completes.
+	newCreateBatcher := func(nodeClaimNames ...string) (*batcher.CreateBatcher, client.Client) {
+		builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+		for _, name := range nodeClaimNames {
+			builder = builder.WithObjects(&karpv1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+			})
+		}
+		kubeClient := builder.Build()
+		return batcher.NewCreateBatcher(ctx, kubeClient, fakeMP, fakeMDP, batcher.NewMDLockManager()), kubeClient
+	}
+
+	// expectMachineLabeled asserts that the Machine has the NodePoolMemberLabel.
+	expectMachineLabeled := func(name, ns string) {
+		GinkgoHelper()
+		m := fakeMP.GetMachine(name, ns)
+		Expect(m).NotTo(BeNil())
+		Expect(m.Labels).To(HaveKeyWithValue(providers.NodePoolMemberLabel, ""))
+	}
+
+	// expectNodeClaimAnnotated asserts that the NodeClaim has the Machine annotation.
+	expectNodeClaimAnnotated := func(kubeClient client.Client, ncName, expectedMachineRef string) {
+		GinkgoHelper()
+		nc := &karpv1.NodeClaim{}
+		Expect(kubeClient.Get(ctx, client.ObjectKey{Name: ncName}, nc)).To(Succeed())
+		Expect(nc.Annotations).To(HaveKeyWithValue(providers.MachineAnnotation, expectedMachineRef))
+	}
+
+	It("should reuse unclaimed machines without incrementing replicas", func() {
+		// MD at 5 replicas with 5 unclaimed machines already present --
+		// the batcher should claim them without touching replicas.
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 5))
+		for i := range 5 {
+			fakeMP.AddMachine(newMachineForMD(fmt.Sprintf("machine-%d", i), "default", "md-0"))
+		}
+
+		ncNames := []string{"nc-0", "nc-1", "nc-2", "nc-3", "nc-4"}
+		cb, kubeClient := newCreateBatcher(ncNames...)
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.CreateOutput], 5)
+		for i := range 5 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = cb.Add(ctx, &batcher.CreateInput{
+					NodeClaimName:         ncNames[idx],
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for i, r := range results {
+			Expect(r.Err).NotTo(HaveOccurred())
+			Expect(r.Output).NotTo(BeNil())
+			expectMachineLabeled(r.Output.Machine.Name, "default")
+			expectNodeClaimAnnotated(kubeClient, ncNames[i], "default/"+r.Output.Machine.Name)
+		}
+
+		// No replica increment needed -- existing unclaimed machines covered the demand.
+		Expect(fakeMDP.GetCallCount.Load()).To(BeNumerically("==", 1))
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 0))
+
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 5))
+	})
+
+	It("should batch different MachineDeployments into separate calls", func() {
+		// Replicas match existing unclaimed machine counts.
+		fakeMDP.AddMD(newMachineDeployment("md-east", "default", 4))
+		fakeMDP.AddMD(newMachineDeployment("md-west", "default", 1))
+		for i := range 4 {
+			fakeMP.AddMachine(newMachineForMD(fmt.Sprintf("m-east-%d", i), "default", "md-east"))
+		}
+		fakeMP.AddMachine(newMachineForMD("m-west-0", "default", "md-west"))
+
+		ncNames := []string{"nc-0", "nc-1", "nc-2", "nc-3", "nc-4"}
+		cb, kubeClient := newCreateBatcher(ncNames...)
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.CreateOutput], 5)
+		for i := range 5 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				input := &batcher.CreateInput{
+					NodeClaimName:         ncNames[idx],
+					MachineDeploymentName: "md-east",
+					MachineDeploymentNS:   "default",
+				}
+				if idx == 3 {
+					input.MachineDeploymentName = "md-west"
+				}
+				results[idx] = cb.Add(ctx, input)
+			}(i)
+		}
+		wg.Wait()
+
+		for i, r := range results {
+			Expect(r.Err).NotTo(HaveOccurred())
+			Expect(r.Output).NotTo(BeNil())
+			expectMachineLabeled(r.Output.Machine.Name, "default")
+			expectNodeClaimAnnotated(kubeClient, ncNames[i], "default/"+r.Output.Machine.Name)
+		}
+
+		// Two separate MDs = two separate batch executions, but no
+		// replica increments needed (unclaimed machines cover demand).
+		Expect(fakeMDP.GetCallCount.Load()).To(BeNumerically("==", 2))
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 0))
+
+		mdEast := fakeMDP.GetMD("md-east", "default")
+		Expect(mdEast).NotTo(BeNil())
+		Expect(*mdEast.Spec.Replicas).To(BeNumerically("==", 4))
+
+		mdWest := fakeMDP.GetMD("md-west", "default")
+		Expect(mdWest).NotTo(BeNil())
+		Expect(*mdWest.Spec.Replicas).To(BeNumerically("==", 1))
+	})
+
+	It("should return errors to all callers when MachineDeployment get fails", func() {
+		fakeMDP.GetError = fmt.Errorf("simulated MD get failure")
+		cb, _ := newCreateBatcher("nc-0", "nc-1", "nc-2")
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.CreateOutput], 3)
+		for i := range 3 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = cb.Add(ctx, &batcher.CreateInput{
+					NodeClaimName:         fmt.Sprintf("nc-%d", idx),
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for _, r := range results {
+			Expect(r.Err).To(HaveOccurred())
+			Expect(r.Err.Error()).To(ContainSubstring("simulated MD get failure"))
+			Expect(r.Output).To(BeNil())
+		}
+		// Get was called but Update should never have been reached.
+		Expect(fakeMDP.GetCallCount.Load()).To(BeNumerically("==", 1))
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 0))
+	})
+
+	It("should return errors to all callers when MachineDeployment update fails", func() {
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 0))
+		fakeMDP.UpdateError = fmt.Errorf("simulated MD update failure")
+		cb, _ := newCreateBatcher("nc-0", "nc-1")
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.CreateOutput], 2)
+		for i := range 2 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = cb.Add(ctx, &batcher.CreateInput{
+					NodeClaimName:         fmt.Sprintf("nc-%d", idx),
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for _, r := range results {
+			Expect(r.Err).To(HaveOccurred())
+			Expect(r.Err.Error()).To(ContainSubstring("simulated MD update failure"))
+			Expect(r.Output).To(BeNil())
+		}
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 0))
+
+		Expect(fakeMDP.GetCallCount.Load()).To(BeNumerically("==", 1))
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 1))
+	})
+
+	It("should increment only by deficit and not rollback when too few machines are available", func() {
+		// 2 unclaimed machines already exist at replicas=2. We request 5,
+		// so the batcher increments by 3 (deficit). Only 2 machines can
+		// be claimed (the fake has no async machine creation). Replicas
+		// stays at 5 (no rollback) so retries can pick up remaining machines.
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 2))
+		fakeMP.AddMachine(newMachineForMD("machine-0", "default", "md-0"))
+		fakeMP.AddMachine(newMachineForMD("machine-1", "default", "md-0"))
+
+		ncNames := []string{"nc-0", "nc-1", "nc-2", "nc-3", "nc-4"}
+		cb, kubeClient := newCreateBatcher(ncNames...)
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.CreateOutput], 5)
+		for i := range 5 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = cb.Add(ctx, &batcher.CreateInput{
+					NodeClaimName:         ncNames[idx],
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		var successes, failures int
+		for i, r := range results {
+			if r.Err == nil && r.Output != nil {
+				Expect(r.Output.Machine).NotTo(BeNil())
+				expectMachineLabeled(r.Output.Machine.Name, "default")
+				expectNodeClaimAnnotated(kubeClient, ncNames[i], "default/"+r.Output.Machine.Name)
+				successes++
+			} else {
+				failures++
+			}
+		}
+		Expect(successes).To(Equal(2))
+		Expect(failures).To(Equal(3))
+
+		// Replicas = 2 (original) + 3 (deficit increment) = 5.
+		// No rollback -- retries will eventually claim the remaining machines.
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 5))
+		// Only one Update: the deficit increment.
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 1))
+	})
+})

--- a/pkg/batcher/delete.go
+++ b/pkg/batcher/delete.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batcher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/samber/lo"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers/machine"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers/machinedeployment"
+)
+
+// DeleteInput is the input to a single delete request within a batch.
+type DeleteInput struct {
+	MachineName           string
+	MachineNamespace      string
+	MachineDeploymentName string
+	MachineDeploymentNS   string
+}
+
+func (d DeleteInput) BatchKey() string {
+	return d.MachineDeploymentNS + "/" + d.MachineDeploymentName
+}
+
+// DeleteOutput is the result of a successful Machine deletion request.
+type DeleteOutput struct{}
+
+// DeleteBatcher coalesces concurrent CloudProvider.Delete calls targeting the
+// same MachineDeployment into a single replica decrement.
+type DeleteBatcher struct {
+	batcher *Batcher[DeleteInput, DeleteOutput]
+}
+
+func NewDeleteBatcher(
+	ctx context.Context,
+	machineProvider machine.Provider,
+	mdProvider machinedeployment.Provider,
+	mdLock *MDLockManager,
+) *DeleteBatcher {
+	options := Options[DeleteInput, DeleteOutput]{
+		Name:          "delete_machine",
+		IdleTimeout:   100 * time.Millisecond,
+		MaxTimeout:    1 * time.Second,
+		RequestHasher: BatchKeyHasher[DeleteInput],
+		BatchExecutor: execDeleteBatch(machineProvider, mdProvider, mdLock),
+	}
+	return &DeleteBatcher{batcher: NewBatcher(ctx, options)}
+}
+
+func (b *DeleteBatcher) Add(ctx context.Context, input *DeleteInput) Result[DeleteOutput] {
+	return b.batcher.Add(ctx, input)
+}
+
+// execDeleteBatch returns a BatchExecutor that deletes Machines from a
+// MachineDeployment. The algorithm is:
+//
+//  1. Annotate each Machine with the CAPI delete-machine annotation in
+//     parallel. This tells the MachineSet controller to prefer deleting these
+//     specific Machines when replicas are decremented.
+//  2. Lock the MachineDeployment and decrement spec.replicas by the number of
+//     successfully annotated Machines. If the decrement fails, we roll back
+//     the annotations so the Machines are not orphaned.
+//
+// Concurrent create batches do not interfere: the replica read-modify-write
+// is serialized by MDLockManager, and create's poll skips Machines that carry
+// the delete-machine annotation, so a Machine being deleted will not be
+// claimed by a concurrent create batch.
+func execDeleteBatch(
+	machineProvider machine.Provider,
+	mdProvider machinedeployment.Provider,
+	mdLock *MDLockManager,
+) BatchExecutor[DeleteInput, DeleteOutput] {
+	return func(ctx context.Context, inputs []*DeleteInput) []Result[DeleteOutput] {
+		n := len(inputs)
+		results := make([]Result[DeleteOutput], n)
+
+		if n == 0 {
+			return results
+		}
+
+		mdName := inputs[0].MachineDeploymentName
+		mdNS := inputs[0].MachineDeploymentNS
+		mdKey := mdNS + "/" + mdName
+
+		// 1) Annotate each Machine for deletion (parallel, unlocked).
+		// TODO(maxcao13): Use wg.Go when we bump go.mod to 1.25
+		var wg sync.WaitGroup
+		annotated := make([]bool, n)
+		for i, input := range inputs {
+			wg.Add(1)
+			go func(idx int, machineName, machineNS string) {
+				defer wg.Done()
+				fresh, err := machineProvider.Get(ctx, machineName, machineNS)
+				if err != nil {
+					results[idx] = Result[DeleteOutput]{Err: fmt.Errorf("unable to get Machine %q: %w", machineName, err)}
+					return
+				}
+				if err := machineProvider.AddDeleteAnnotation(ctx, fresh); err != nil {
+					results[idx] = Result[DeleteOutput]{Err: fmt.Errorf("unable to annotate Machine %q for deletion: %w", machineName, err)}
+					return
+				}
+				annotated[idx] = true
+			}(i, input.MachineName, input.MachineNamespace)
+		}
+		wg.Wait()
+
+		// We can get partial fulfillment of the annotation step, so we only
+		// decrement replicas by the number that were successfully annotated.
+		successCount := int32(lo.CountBy(annotated, func(b bool) bool { return b }))
+
+		log.FromContext(ctx).V(1).Info("delete batch", "machineDeployment", mdKey, "requests", n, "annotated", successCount)
+
+		if successCount == 0 {
+			return results
+		}
+
+		// 2) Lock and decrement replicas by the number of annotated Machines.
+		mdLock.Lock(mdKey)
+		md, err := mdProvider.Get(ctx, mdName, mdNS)
+		if err != nil {
+			mdLock.Unlock(mdKey)
+			log.FromContext(ctx).Error(err, "delete batch: unable to get MachineDeployment", "machineDeployment", mdName)
+			rollbackDeleteAnnotations(ctx, machineProvider, inputs, annotated)
+			for i := range results {
+				if annotated[i] {
+					results[i] = Result[DeleteOutput]{Err: fmt.Errorf("unable to get MachineDeployment %q for replica decrement: %w", mdName, err)}
+				}
+			}
+			return results
+		}
+
+		currentReplicas := ptr.Deref(md.Spec.Replicas, 0)
+		newReplicas := currentReplicas - successCount
+		if newReplicas < 0 {
+			newReplicas = 0
+		}
+		md.Spec.Replicas = ptr.To(newReplicas)
+
+		if err := mdProvider.Update(ctx, md); err != nil {
+			mdLock.Unlock(mdKey)
+			log.FromContext(ctx).Error(err, "delete batch: unable to update MachineDeployment replicas", "machineDeployment", mdName)
+			rollbackDeleteAnnotations(ctx, machineProvider, inputs, annotated)
+			for i := range results {
+				if annotated[i] {
+					results[i] = Result[DeleteOutput]{Err: fmt.Errorf("unable to update MachineDeployment %q replicas: %w", mdName, err)}
+				}
+			}
+			return results
+		}
+		mdLock.Unlock(mdKey)
+
+		// Deliver success results for annotated Machines.
+		for i := range results {
+			if annotated[i] {
+				results[i] = Result[DeleteOutput]{Output: &DeleteOutput{}}
+			}
+		}
+
+		return results
+	}
+}
+
+// rollbackDeleteAnnotations removes the delete-machine annotation from
+// Machines that were annotated but whose replica decrement failed. This
+// prevents the MachineSet controller from deleting Machines that Karpenter
+// did not successfully request deletion for.
+func rollbackDeleteAnnotations(ctx context.Context, machineProvider machine.Provider, inputs []*DeleteInput, annotated []bool) {
+	for i, ok := range annotated {
+		if !ok {
+			continue
+		}
+		fresh, err := machineProvider.Get(ctx, inputs[i].MachineName, inputs[i].MachineNamespace)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "delete batch rollback: unable to re-fetch Machine", "machine", inputs[i].MachineName)
+			continue
+		}
+		if err := machineProvider.RemoveDeleteAnnotation(ctx, fresh); err != nil {
+			log.FromContext(ctx).Error(err, "delete batch rollback: unable to remove delete annotation from Machine", "machine", fresh.Name)
+		}
+	}
+}

--- a/pkg/batcher/delete_test.go
+++ b/pkg/batcher/delete_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batcher_test
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/batcher"
+)
+
+var _ = Describe("Delete Batching", func() {
+	var (
+		fakeMP  *fakeMachineProvider
+		fakeMDP *fakeMDProvider
+		db      *batcher.DeleteBatcher
+	)
+
+	BeforeEach(func() {
+		fakeMP = newFakeMachineProvider()
+		fakeMDP = newFakeMDProvider()
+		db = batcher.NewDeleteBatcher(ctx, fakeMP, fakeMDP, batcher.NewMDLockManager())
+	})
+
+	It("should batch the same MachineDeployment deletes into a single replica decrement", func() {
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 5))
+
+		for i := range 5 {
+			fakeMP.AddMachine(newMachineForMD(fmt.Sprintf("machine-%d", i), "default", "md-0"))
+		}
+
+		var wg sync.WaitGroup
+		var successCount atomic.Int64
+		for i := range 5 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				result := db.Add(ctx, &batcher.DeleteInput{
+					MachineName:           fmt.Sprintf("machine-%d", idx),
+					MachineNamespace:      "default",
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+				if result.Err == nil && result.Output != nil {
+					successCount.Add(1)
+				}
+			}(i)
+		}
+		wg.Wait()
+
+		Expect(successCount.Load()).To(BeNumerically("==", 5))
+
+		// One batched Get + one batched Update (not 5 individual calls).
+		Expect(fakeMDP.GetCallCount.Load()).To(BeNumerically("==", 1))
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 1))
+		// All 5 machines annotated for deletion in one batch.
+		Expect(fakeMP.AddDeleteAnnotationCount.Load()).To(BeNumerically("==", 5))
+
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 0))
+
+		for i := range 5 {
+			m := fakeMP.GetMachine(fmt.Sprintf("machine-%d", i), "default")
+			Expect(m).NotTo(BeNil())
+			Expect(m.Annotations).To(HaveKey(capiv1beta1.DeleteMachineAnnotation))
+		}
+	})
+
+	It("should batch different MachineDeployments into separate calls", func() {
+		fakeMDP.AddMD(newMachineDeployment("md-east", "default", 4))
+		fakeMDP.AddMD(newMachineDeployment("md-west", "default", 1))
+
+		eastMachines := []string{"m-east-0", "m-east-1", "m-east-2", "m-east-3"}
+		for _, name := range eastMachines {
+			fakeMP.AddMachine(newMachineForMD(name, "default", "md-east"))
+		}
+		fakeMP.AddMachine(newMachineForMD("m-west-0", "default", "md-west"))
+
+		type testCase struct {
+			machineName string
+			mdName      string
+		}
+		cases := []testCase{
+			{"m-east-0", "md-east"},
+			{"m-east-1", "md-east"},
+			{"m-east-2", "md-east"},
+			{"m-west-0", "md-west"},
+			{"m-east-3", "md-east"},
+		}
+
+		var wg sync.WaitGroup
+		var eastSuccess, westSuccess atomic.Int64
+		for _, tc := range cases {
+			wg.Add(1)
+			go func(tc testCase) {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				result := db.Add(ctx, &batcher.DeleteInput{
+					MachineName:           tc.machineName,
+					MachineNamespace:      "default",
+					MachineDeploymentName: tc.mdName,
+					MachineDeploymentNS:   "default",
+				})
+				if result.Err == nil && result.Output != nil {
+					if tc.mdName == "md-east" {
+						eastSuccess.Add(1)
+					} else {
+						westSuccess.Add(1)
+					}
+				}
+			}(tc)
+		}
+		wg.Wait()
+
+		Expect(eastSuccess.Load()).To(BeNumerically("==", 4))
+		Expect(westSuccess.Load()).To(BeNumerically("==", 1))
+
+		// Two separate MDs = two separate batch executions.
+		Expect(fakeMDP.GetCallCount.Load()).To(BeNumerically("==", 2))
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 2))
+
+		mdEast := fakeMDP.GetMD("md-east", "default")
+		Expect(mdEast).NotTo(BeNil())
+		Expect(*mdEast.Spec.Replicas).To(BeNumerically("==", 0))
+
+		mdWest := fakeMDP.GetMD("md-west", "default")
+		Expect(mdWest).NotTo(BeNil())
+		Expect(*mdWest.Spec.Replicas).To(BeNumerically("==", 0))
+	})
+
+	It("should return errors to all callers when MachineDeployment update fails", func() {
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 3))
+		fakeMDP.UpdateError = fmt.Errorf("simulated MD update failure")
+
+		for i := range 3 {
+			fakeMP.AddMachine(newMachineForMD(fmt.Sprintf("machine-%d", i), "default", "md-0"))
+		}
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.DeleteOutput], 3)
+		for i := range 3 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = db.Add(ctx, &batcher.DeleteInput{
+					MachineName:           fmt.Sprintf("machine-%d", idx),
+					MachineNamespace:      "default",
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for _, r := range results {
+			Expect(r.Err).To(HaveOccurred())
+			Expect(r.Err.Error()).To(ContainSubstring("simulated MD update failure"))
+		}
+		// Annotations added then rolled back; replicas unchanged at 3.
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 3))
+
+		for i := range 3 {
+			m := fakeMP.GetMachine(fmt.Sprintf("machine-%d", i), "default")
+			Expect(m).NotTo(BeNil())
+			Expect(m.Annotations).NotTo(HaveKey(capiv1beta1.DeleteMachineAnnotation))
+		}
+	})
+
+	It("should only fail the affected caller when annotation fails for one machine", func() {
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 3))
+
+		fakeMP.AddMachine(newMachineForMD("machine-0", "default", "md-0"))
+		fakeMP.AddMachine(newMachineForMD("machine-1", "default", "md-0"))
+		// machine-2 is intentionally NOT added so AddDeleteAnnotation will fail with "not found".
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.DeleteOutput], 3)
+		for i := range 3 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = db.Add(ctx, &batcher.DeleteInput{
+					MachineName:           fmt.Sprintf("machine-%d", idx),
+					MachineNamespace:      "default",
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		var successes, failures int
+		for _, r := range results {
+			if r.Err == nil && r.Output != nil {
+				successes++
+			} else {
+				Expect(r.Err).To(HaveOccurred())
+				failures++
+			}
+		}
+		Expect(successes).To(Equal(2))
+		Expect(failures).To(Equal(1))
+
+		// Replicas decremented by 2 (only the successfully annotated machines).
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 1))
+		// Only one Update call for the batch (not per-machine).
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 1))
+	})
+
+	It("should rollback delete annotations when MachineDeployment get fails", func() {
+		fakeMDP.GetError = fmt.Errorf("simulated MD get failure")
+
+		for i := range 2 {
+			fakeMP.AddMachine(newMachineForMD(fmt.Sprintf("machine-%d", i), "default", "md-0"))
+		}
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.DeleteOutput], 2)
+		for i := range 2 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = db.Add(ctx, &batcher.DeleteInput{
+					MachineName:           fmt.Sprintf("machine-%d", idx),
+					MachineNamespace:      "default",
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for _, r := range results {
+			Expect(r.Err).To(HaveOccurred())
+			Expect(r.Err.Error()).To(ContainSubstring("simulated MD get failure"))
+		}
+		// Get was called but Update should never have been reached.
+		Expect(fakeMDP.GetCallCount.Load()).To(BeNumerically("==", 1))
+		Expect(fakeMDP.UpdateCallCount.Load()).To(BeNumerically("==", 0))
+
+		for i := range 2 {
+			m := fakeMP.GetMachine(fmt.Sprintf("machine-%d", i), "default")
+			Expect(m).NotTo(BeNil())
+			Expect(m.Annotations).NotTo(HaveKey(capiv1beta1.DeleteMachineAnnotation))
+		}
+	})
+
+	It("should clamp replicas to zero when decrementing below zero", func() {
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 1))
+
+		for i := range 3 {
+			fakeMP.AddMachine(newMachineForMD(fmt.Sprintf("machine-%d", i), "default", "md-0"))
+		}
+
+		var wg sync.WaitGroup
+		results := make([]batcher.Result[batcher.DeleteOutput], 3)
+		for i := range 3 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				results[idx] = db.Add(ctx, &batcher.DeleteInput{
+					MachineName:           fmt.Sprintf("machine-%d", idx),
+					MachineNamespace:      "default",
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for _, r := range results {
+			Expect(r.Err).NotTo(HaveOccurred())
+			Expect(r.Output).NotTo(BeNil())
+		}
+		// 3 deletes with initial replicas=1 should clamp to 0.
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 0))
+		// All 3 machines annotated for deletion.
+		Expect(fakeMP.AddDeleteAnnotationCount.Load()).To(BeNumerically("==", 3))
+	})
+})

--- a/pkg/batcher/fake_test.go
+++ b/pkg/batcher/fake_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batcher_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// fakeMachineProvider implements machine.Provider for unit tests.
+type fakeMachineProvider struct {
+	mu       sync.Mutex
+	machines map[string]*capiv1beta1.Machine // keyed by "namespace/name"
+
+	GetCallCount              atomic.Int64
+	ListCallCount             atomic.Int64
+	UpdateCallCount           atomic.Int64
+	AddDeleteAnnotationCount  atomic.Int64
+	RemoveDeleteAnnotationCount atomic.Int64
+
+	GetError              error
+	ListError             error
+	UpdateError           error
+	AddDeleteAnnotationError    error
+	RemoveDeleteAnnotationError error
+}
+
+func newFakeMachineProvider() *fakeMachineProvider {
+	return &fakeMachineProvider{
+		machines: make(map[string]*capiv1beta1.Machine),
+	}
+}
+
+func (f *fakeMachineProvider) key(ns, name string) string {
+	return ns + "/" + name
+}
+
+func (f *fakeMachineProvider) AddMachine(m *capiv1beta1.Machine) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.machines[f.key(m.Namespace, m.Name)] = m.DeepCopy()
+}
+
+func (f *fakeMachineProvider) GetMachine(name, ns string) *capiv1beta1.Machine {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if m, ok := f.machines[f.key(ns, name)]; ok {
+		return m.DeepCopy()
+	}
+	return nil
+}
+
+func (f *fakeMachineProvider) Get(_ context.Context, name string, namespace string) (*capiv1beta1.Machine, error) {
+	f.GetCallCount.Add(1)
+	if f.GetError != nil {
+		return nil, f.GetError
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m, ok := f.machines[f.key(namespace, name)]
+	if !ok {
+		return nil, fmt.Errorf("machine %s/%s not found", namespace, name)
+	}
+	return m.DeepCopy(), nil
+}
+
+func (f *fakeMachineProvider) GetByProviderID(_ context.Context, _ string) (*capiv1beta1.Machine, error) {
+	return nil, fmt.Errorf("not implemented in fake")
+}
+
+func (f *fakeMachineProvider) List(_ context.Context, namespace string, selector *metav1.LabelSelector) ([]*capiv1beta1.Machine, error) {
+	f.ListCallCount.Add(1)
+	if f.ListError != nil {
+		return nil, f.ListError
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	sel, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*capiv1beta1.Machine
+	for _, m := range f.machines {
+		if namespace != "" && m.Namespace != namespace {
+			continue
+		}
+		if sel != nil && !sel.Matches(labelSet(m.Labels)) {
+			continue
+		}
+		result = append(result, m.DeepCopy())
+	}
+	return result, nil
+}
+
+func (f *fakeMachineProvider) IsDeleting(m *capiv1beta1.Machine) bool {
+	return m != nil && !m.GetDeletionTimestamp().IsZero()
+}
+
+func (f *fakeMachineProvider) AddDeleteAnnotation(_ context.Context, m *capiv1beta1.Machine) error {
+	f.AddDeleteAnnotationCount.Add(1)
+	if f.AddDeleteAnnotationError != nil {
+		return f.AddDeleteAnnotationError
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	stored, ok := f.machines[f.key(m.Namespace, m.Name)]
+	if !ok {
+		return fmt.Errorf("machine %s/%s not found", m.Namespace, m.Name)
+	}
+	annotations := stored.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[capiv1beta1.DeleteMachineAnnotation] = "true"
+	stored.SetAnnotations(annotations)
+	return nil
+}
+
+func (f *fakeMachineProvider) RemoveDeleteAnnotation(_ context.Context, m *capiv1beta1.Machine) error {
+	f.RemoveDeleteAnnotationCount.Add(1)
+	if f.RemoveDeleteAnnotationError != nil {
+		return f.RemoveDeleteAnnotationError
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	stored, ok := f.machines[f.key(m.Namespace, m.Name)]
+	if !ok {
+		return fmt.Errorf("machine %s/%s not found", m.Namespace, m.Name)
+	}
+	annotations := stored.GetAnnotations()
+	delete(annotations, capiv1beta1.DeleteMachineAnnotation)
+	stored.SetAnnotations(annotations)
+	return nil
+}
+
+func (f *fakeMachineProvider) Update(_ context.Context, m *capiv1beta1.Machine) error {
+	f.UpdateCallCount.Add(1)
+	if f.UpdateError != nil {
+		return f.UpdateError
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.machines[f.key(m.Namespace, m.Name)] = m.DeepCopy()
+	return nil
+}
+
+func (f *fakeMachineProvider) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.machines = make(map[string]*capiv1beta1.Machine)
+	f.GetCallCount.Store(0)
+	f.ListCallCount.Store(0)
+	f.UpdateCallCount.Store(0)
+	f.AddDeleteAnnotationCount.Store(0)
+	f.RemoveDeleteAnnotationCount.Store(0)
+	f.GetError = nil
+	f.ListError = nil
+	f.UpdateError = nil
+	f.AddDeleteAnnotationError = nil
+	f.RemoveDeleteAnnotationError = nil
+}
+
+// fakeMDProvider implements machinedeployment.Provider for unit tests.
+type fakeMDProvider struct {
+	mu  sync.Mutex
+	mds map[string]*capiv1beta1.MachineDeployment // keyed by "namespace/name"
+
+	GetCallCount    atomic.Int64
+	UpdateCallCount atomic.Int64
+
+	GetError    error
+	UpdateError error
+}
+
+func newFakeMDProvider() *fakeMDProvider {
+	return &fakeMDProvider{
+		mds: make(map[string]*capiv1beta1.MachineDeployment),
+	}
+}
+
+func (f *fakeMDProvider) key(ns, name string) string {
+	return ns + "/" + name
+}
+
+func (f *fakeMDProvider) AddMD(md *capiv1beta1.MachineDeployment) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mds[f.key(md.Namespace, md.Name)] = md.DeepCopy()
+}
+
+func (f *fakeMDProvider) GetMD(name, ns string) *capiv1beta1.MachineDeployment {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if md, ok := f.mds[f.key(ns, name)]; ok {
+		return md.DeepCopy()
+	}
+	return nil
+}
+
+func (f *fakeMDProvider) Get(_ context.Context, name string, namespace string) (*capiv1beta1.MachineDeployment, error) {
+	f.GetCallCount.Add(1)
+	if f.GetError != nil {
+		return nil, f.GetError
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	md, ok := f.mds[f.key(namespace, name)]
+	if !ok {
+		return nil, fmt.Errorf("machinedeployment %s/%s not found", namespace, name)
+	}
+	return md.DeepCopy(), nil
+}
+
+func (f *fakeMDProvider) List(_ context.Context, _ *metav1.LabelSelector) ([]*capiv1beta1.MachineDeployment, error) {
+	return nil, fmt.Errorf("not implemented in fake")
+}
+
+func (f *fakeMDProvider) Update(_ context.Context, md *capiv1beta1.MachineDeployment) error {
+	f.UpdateCallCount.Add(1)
+	if f.UpdateError != nil {
+		return f.UpdateError
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mds[f.key(md.Namespace, md.Name)] = md.DeepCopy()
+	return nil
+}
+
+func (f *fakeMDProvider) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mds = make(map[string]*capiv1beta1.MachineDeployment)
+	f.GetCallCount.Store(0)
+	f.UpdateCallCount.Store(0)
+	f.GetError = nil
+	f.UpdateError = nil
+}
+
+// labelSet adapts a map[string]string to labels.Labels for selector matching.
+type labelSet map[string]string
+
+func (l labelSet) Has(key string) bool {
+	_, ok := l[key]
+	return ok
+}
+
+func (l labelSet) Get(key string) string {
+	return l[key]
+}
+
+// newMachineDeployment creates a MachineDeployment with the given name, namespace, and replicas.
+func newMachineDeployment(name, namespace string, replicas int32) *capiv1beta1.MachineDeployment {
+	return &capiv1beta1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: capiv1beta1.MachineDeploymentSpec{
+			Replicas: ptr.To(replicas),
+		},
+	}
+}
+
+// newMachineForMD creates a Machine belonging to the given MachineDeployment.
+func newMachineForMD(name, namespace, mdName string) *capiv1beta1.Machine {
+	return &capiv1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				capiv1beta1.MachineDeploymentNameLabel: mdName,
+			},
+		},
+	}
+}

--- a/pkg/batcher/mdlock.go
+++ b/pkg/batcher/mdlock.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batcher
+
+import "sync"
+
+// MDLockManager provides per-MachineDeployment mutexes so that create and
+// delete batch executors serialise their replica read-modify-write cycles
+// on the same MachineDeployment.
+type MDLockManager struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func NewMDLockManager() *MDLockManager {
+	return &MDLockManager{locks: map[string]*sync.Mutex{}}
+}
+
+func (m *MDLockManager) Lock(key string) {
+	m.mu.Lock()
+	l, ok := m.locks[key]
+	if !ok {
+		l = &sync.Mutex{}
+		m.locks[key] = l
+	}
+	m.mu.Unlock()
+	l.Lock()
+}
+
+func (m *MDLockManager) Unlock(key string) {
+	m.mu.Lock()
+	l := m.locks[key]
+	m.mu.Unlock()
+	l.Unlock()
+}

--- a/pkg/batcher/suite_test.go
+++ b/pkg/batcher/suite_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batcher_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/batcher"
+)
+
+var ctx context.Context
+var cancel context.CancelFunc
+
+func init() {
+	_ = capiv1beta1.AddToScheme(scheme.Scheme)
+}
+
+func TestBatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Batcher Suite")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+})
+
+var _ = Describe("Concurrent Create and Delete", func() {
+	It("should not corrupt replicas when create and delete batches run concurrently on the same MD", func() {
+		fakeMP := newFakeMachineProvider()
+		fakeMDP := newFakeMDProvider()
+		mdLock := batcher.NewMDLockManager()
+
+		// MD starts at 8 replicas: 5 claimed machines + 3 unclaimed
+		// (simulating leftovers from a previous batch).
+		fakeMDP.AddMD(newMachineDeployment("md-0", "default", 8))
+		for i := range 8 {
+			m := newMachineForMD(fmt.Sprintf("machine-%d", i), "default", "md-0")
+			if i < 5 {
+				m.Labels["karpenter.sh/nodepool"] = ""
+			}
+			fakeMP.AddMachine(m)
+		}
+
+		// Create batcher: add 3 new nodes. Pre-seed NodeClaims for binding.
+		ncNames := []string{"nc-0", "nc-1", "nc-2"}
+		builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+		for _, name := range ncNames {
+			builder = builder.WithObjects(&karpv1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+			})
+		}
+		cb := batcher.NewCreateBatcher(ctx, builder.Build(), fakeMP, fakeMDP, mdLock)
+
+		// Delete batcher: remove 2 existing claimed machines.
+		db := batcher.NewDeleteBatcher(ctx, fakeMP, fakeMDP, mdLock)
+
+		var wg sync.WaitGroup
+
+		// Fire 3 creates concurrently.
+		createResults := make([]batcher.Result[batcher.CreateOutput], 3)
+		for i := range 3 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				createResults[idx] = cb.Add(ctx, &batcher.CreateInput{
+					NodeClaimName:         ncNames[idx],
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+
+		// Fire 2 deletes concurrently.
+		deleteResults := make([]batcher.Result[batcher.DeleteOutput], 2)
+		for i := range 2 {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				deleteResults[idx] = db.Add(ctx, &batcher.DeleteInput{
+					MachineName:           fmt.Sprintf("machine-%d", idx),
+					MachineNamespace:      "default",
+					MachineDeploymentName: "md-0",
+					MachineDeploymentNS:   "default",
+				})
+			}(i)
+		}
+
+		wg.Wait()
+
+		// All operations should succeed.
+		for _, r := range createResults {
+			Expect(r.Err).NotTo(HaveOccurred())
+			Expect(r.Output).NotTo(BeNil())
+		}
+		for _, r := range deleteResults {
+			Expect(r.Err).NotTo(HaveOccurred())
+			Expect(r.Output).NotTo(BeNil())
+		}
+
+		// Create found 3 unclaimed machines (machine-5,machine-6,machine-7) so no increment.
+		// Delete decremented by 2. Final: 8 - 2 = 6.
+		md := fakeMDP.GetMD("md-0", "default")
+		Expect(md).NotTo(BeNil())
+		Expect(*md.Spec.Replicas).To(BeNumerically("==", 6))
+	})
+})

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -21,24 +21,21 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/apis/v1alpha1"
+	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/batcher"
 	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers"
 	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers/machine"
 	"sigs.k8s.io/karpenter-provider-cluster-api/pkg/providers/machinedeployment"
@@ -58,15 +55,16 @@ const (
 	labelsKey       = "capacity.cluster-autoscaler.kubernetes.io/labels"
 	taintsKey       = "capacity.cluster-autoscaler.kubernetes.io/taints"
 	maxPodsKey      = "capacity.cluster-autoscaler.kubernetes.io/maxPods"
-
-	machineAnnotation = "cluster.x-k8s.io/machine"
 )
 
 func NewCloudProvider(ctx context.Context, kubeClient client.Client, machineProvider machine.Provider, machineDeploymentProvider machinedeployment.Provider) *CloudProvider {
+	mdLock := batcher.NewMDLockManager()
 	return &CloudProvider{
 		kubeClient:                kubeClient,
 		machineProvider:           machineProvider,
 		machineDeploymentProvider: machineDeploymentProvider,
+		createBatcher:             batcher.NewCreateBatcher(ctx, kubeClient, machineProvider, machineDeploymentProvider, mdLock),
+		deleteBatcher:             batcher.NewDeleteBatcher(ctx, machineProvider, machineDeploymentProvider, mdLock),
 	}
 }
 
@@ -79,62 +77,53 @@ type ClusterAPIInstanceType struct {
 
 type CloudProvider struct {
 	kubeClient                client.Client
-	accessLock                sync.Mutex
 	machineProvider           machine.Provider
 	machineDeploymentProvider machinedeployment.Provider
+	createBatcher             *batcher.CreateBatcher
+	deleteBatcher             *batcher.DeleteBatcher
 }
 
 func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*karpv1.NodeClaim, error) {
-	// to eliminate racing if multiple creation occur, we gate access to this function
-	c.accessLock.Lock()
-	defer c.accessLock.Unlock()
-
 	if nodeClaim == nil {
 		return nil, fmt.Errorf("cannot satisfy create, NodeClaim is nil")
 	}
 
-	machineDeployment, machine, err := c.provisionMachine(ctx, nodeClaim)
+	// If the NodeClaim already has a Machine annotation, just
+	// fetch the existing Machine and return it.
+	if machineAnno, ok := nodeClaim.Annotations[providers.MachineAnnotation]; ok {
+		return c.getExistingMachine(ctx, machineAnno)
+	}
+
+	instanceType, err := c.resolveInstanceType(ctx, nodeClaim)
 	if err != nil {
 		return nil, err
 	}
 
+	result := c.createBatcher.Add(ctx, &batcher.CreateInput{
+		NodeClaimName:         nodeClaim.Name,
+		MachineDeploymentName: instanceType.MachineDeploymentName,
+		MachineDeploymentNS:   instanceType.MachineDeploymentNamespace,
+	})
+	if result.Err != nil {
+		return nil, fmt.Errorf("launching nodeclaim: %w", result.Err)
+	}
+
+	machine := result.Output.Machine
 	if machine.Spec.ProviderID == nil {
 		return nil, fmt.Errorf("cannot satisfy create, waiting for Machine %q to have ProviderID", machine.Name)
 	}
 
 	//  fill out nodeclaim with details
-	createdNodeClaim := createNodeClaimFromMachineDeployment(machineDeployment)
+	createdNodeClaim := createNodeClaimFromMachineDeployment(result.Output.MachineDeployment)
 	createdNodeClaim.Status.ProviderID = *machine.Spec.ProviderID
 
 	return createdNodeClaim, nil
 }
 
 func (c *CloudProvider) Delete(ctx context.Context, nodeClaim *karpv1.NodeClaim) error {
-	// to eliminate racing if multiple deletion occur, we gate access to this function
-	c.accessLock.Lock()
-	defer c.accessLock.Unlock()
-
-	var machine *capiv1beta1.Machine
-	var err error
-
-	// find machine
-	if len(nodeClaim.Status.ProviderID) != 0 {
-		machine, err = c.machineProvider.GetByProviderID(ctx, nodeClaim.Status.ProviderID)
-		if err != nil {
-			return fmt.Errorf("error finding Machine with provider ID %q to Delete NodeClaim %q: %w", nodeClaim.Status.ProviderID, nodeClaim.Name, err)
-		}
-	} else if machineAnno, ok := nodeClaim.Annotations[machineAnnotation]; ok {
-		machineNamespace, machineName, err := parseMachineAnnotation(machineAnno)
-		if err != nil {
-			return fmt.Errorf("error parsing machine annotation: %w", err)
-		}
-
-		machine, err = c.machineProvider.Get(ctx, machineName, machineNamespace)
-		if err != nil {
-			return fmt.Errorf("error finding Machine %q in namespace %s to Delete NodeClaim %q: %w", machineName, machineNamespace, nodeClaim.Name, err)
-		}
-	} else {
-		return fmt.Errorf("NodeClaim %q does not have a provider ID or Machine annotations, cannot delete", nodeClaim.Name)
+	machine, err := c.findMachineForNodeClaim(ctx, nodeClaim)
+	if err != nil {
+		return err
 	}
 
 	if machine == nil {
@@ -161,26 +150,13 @@ func (c *CloudProvider) Delete(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 		return fmt.Errorf("unable to delete NodeClaim %q, MachineDeployment %q is already at zero replicas", nodeClaim.Name, machineDeployment.Name)
 	}
 
-	// mark the machine for deletion before decrementing replicas to protect against the wrong machine being removed
-	err = c.machineProvider.AddDeleteAnnotation(ctx, machine)
-	if err != nil {
-		return fmt.Errorf("unable to delete NodeClaim %q, cannot annotate Machine %q for deletion: %w", nodeClaim.Name, machine.Name, err)
-	}
-
-	//   and reduce machinedeployment replicas
-	updatedReplicas := *machineDeployment.Spec.Replicas - 1
-	machineDeployment.Spec.Replicas = ptr.To(updatedReplicas)
-	err = c.machineDeploymentProvider.Update(ctx, machineDeployment)
-	if err != nil {
-		// cleanup the machine delete annotation so we don't affect future replica changes
-		if err := c.machineProvider.RemoveDeleteAnnotation(ctx, machine); err != nil {
-			return fmt.Errorf("unable to delete NodeClaim %q, cannot remove delete annotation for Machine %q during cleanup: %w", nodeClaim.Name, machine.Name, err)
-		}
-
-		return fmt.Errorf("unable to delete NodeClaim %q, cannot update MachineDeployment %q replicas: %w", nodeClaim.Name, machineDeployment.Name, err)
-	}
-
-	return nil
+	result := c.deleteBatcher.Add(ctx, &batcher.DeleteInput{
+		MachineName:           machine.Name,
+		MachineNamespace:      machine.Namespace,
+		MachineDeploymentName: machineDeployment.Name,
+		MachineDeploymentNS:   machineDeployment.Namespace,
+	})
+	return result.Err
 }
 
 // Get returns a NodeClaim for the Machine object with the supplied provider ID, or nil if not found.
@@ -282,47 +258,49 @@ func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 	return []cloudprovider.RepairPolicy{}
 }
 
-// ProvisionMachine ensures a CAPI Machine exists for the given NodeClaim.
-// It creates the Machine if missing, or "gets" it to confirm the asynchronous provisioning status.
-func (c *CloudProvider) provisionMachine(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*capiv1beta1.MachineDeployment, *capiv1beta1.Machine, error) {
-	machineAnno, ok := nodeClaim.Annotations[machineAnnotation]
-	if !ok {
-		return c.createMachine(ctx, nodeClaim)
-	}
-
-	machineNamespace, machineName, err := parseMachineAnnotation(machineAnno)
+// getExistingMachine handles the resume path when a NodeClaim already has a
+// Machine annotation from a previous Create attempt.
+func (c *CloudProvider) getExistingMachine(ctx context.Context, machineAnno string) (*karpv1.NodeClaim, error) {
+	machineNamespace, machineName, err := providers.ParseMachineAnnotation(machineAnno)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing machine annotation: %w", err)
+		return nil, fmt.Errorf("error parsing machine annotation: %w", err)
 	}
 
-	machine, err := c.machineProvider.Get(ctx, machineName, machineNamespace)
+	m, err := c.machineProvider.Get(ctx, machineName, machineNamespace)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get NodeClaim's Machine %s : %w", machineName, err)
+		return nil, fmt.Errorf("failed to get NodeClaim's Machine %s: %w", machineName, err)
 	}
 
-	machineDeployment, err := c.machineDeploymentFromMachine(ctx, machine)
+	md, err := c.machineDeploymentFromMachine(ctx, m)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get NodeClaim's MachineDeployment %s : %w", machineName, err)
+		return nil, fmt.Errorf("failed to get NodeClaim's MachineDeployment %s: %w", machineName, err)
 	}
 
-	return machineDeployment, machine, nil
+	if m.Spec.ProviderID == nil {
+		return nil, fmt.Errorf("cannot satisfy create, waiting for Machine %q to have ProviderID", m.Name)
+	}
+
+	nc := createNodeClaimFromMachineDeployment(md)
+	nc.Status.ProviderID = *m.Spec.ProviderID
+	return nc, nil
 }
 
-func (c *CloudProvider) createMachine(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*capiv1beta1.MachineDeployment, *capiv1beta1.Machine, error) {
+// resolveInstanceType finds the best matching instance type for a NodeClaim.
+func (c *CloudProvider) resolveInstanceType(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*ClusterAPIInstanceType, error) {
 	nodeClass, err := c.resolveNodeClassFromNodeClaim(ctx, nodeClaim)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot satisfy create, unable to resolve NodeClass from NodeClaim %q: %w", nodeClaim.Name, err)
+		return nil, fmt.Errorf("cannot satisfy create, unable to resolve NodeClass from NodeClaim %q: %w", nodeClaim.Name, err)
 	}
 
 	instanceTypes, err := c.findInstanceTypesForNodeClass(ctx, nodeClass)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot satisfy create, unable to get instance types for NodeClass %q of NodeClaim %q: %w", nodeClass.Name, nodeClaim.Name, err)
+		return nil, fmt.Errorf("cannot satisfy create, unable to get instance types for NodeClass %q of NodeClaim %q: %w", nodeClass.Name, nodeClaim.Name, err)
 	}
 
 	// identify which fit requirements
 	compatibleInstanceTypes := filterCompatibleInstanceTypes(instanceTypes, nodeClaim)
 	if len(compatibleInstanceTypes) == 0 {
-		return nil, nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("cannot satisfy create, no compatible instance types found"))
+		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("cannot satisfy create, no compatible instance types found"))
 	}
 
 	// TODO (elmiko) if multiple instance types are found to be compatible we need to select one.
@@ -331,62 +309,33 @@ func (c *CloudProvider) createMachine(ctx context.Context, nodeClaim *karpv1.Nod
 	slices.SortFunc(compatibleInstanceTypes, func(a, b *ClusterAPIInstanceType) int {
 		return cmp.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
 	})
-	selectedInstanceType := compatibleInstanceTypes[0]
+	return compatibleInstanceTypes[0], nil
+}
 
-	// once scalable resource is identified, increase replicas
-	machineDeployment, err := c.machineDeploymentProvider.Get(ctx, selectedInstanceType.MachineDeploymentName, selectedInstanceType.MachineDeploymentNamespace)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot satisfy create, unable to find MachineDeployment %q for InstanceType %q: %w", selectedInstanceType.MachineDeploymentName, selectedInstanceType.Name, err)
-	}
-	originalReplicas := *machineDeployment.Spec.Replicas
-	machineDeployment.Spec.Replicas = ptr.To(originalReplicas + 1)
-	if err := c.machineDeploymentProvider.Update(ctx, machineDeployment); err != nil {
-		return nil, nil, fmt.Errorf("cannot satisfy create, unable to update MachineDeployment %q replicas: %w", machineDeployment.Name, err)
-	}
-
-	// TODO (elmiko) it would be nice to have a more elegant solution to the asynchronous machine creation.
-	// Initially, it appeared that we could have a Machine controller which could reconcile new Machines and
-	// then associate them with NodeClaims by using a sentinel value for the Provider ID. But, this may not
-	// work as we expect since the karpenter core can use the Provider ID as a key into one of its internal caches.
-	// For now, the method of waiting for the Machine seemed straightforward although it does make the `Create` method a blocking call.
-	// Try to find an unclaimed Machine resource for 1 minute.
-	machine, err := c.pollForUnclaimedMachineInMachineDeploymentWithTimeout(ctx, machineDeployment, time.Minute)
-	if err != nil {
-		// unable to find a Machine for the NodeClaim, this could be due to timeout or error, but the replica count needs to be reset.
-		// TODO (elmiko) this could probably use improvement to make it more resilient to errors.
-		defer func() {
-			machineDeployment, err = c.machineDeploymentProvider.Get(ctx, selectedInstanceType.MachineDeploymentName, selectedInstanceType.MachineDeploymentNamespace)
-			if err != nil {
-				log.Println(fmt.Errorf("error while recovering from failure to find an unclaimed Machine, unable to find MachineDeployment %q for InstanceType %q: %w", selectedInstanceType.MachineDeploymentName, selectedInstanceType.Name, err))
-			}
-
-			machineDeployment.Spec.Replicas = ptr.To(originalReplicas)
-			if err = c.machineDeploymentProvider.Update(ctx, machineDeployment); err != nil {
-				log.Println(fmt.Errorf("error while recovering from failure to find an unclaimed Machine: %w", err))
-			}
-		}()
-
-		return nil, nil, fmt.Errorf("cannot satisfy create, unable to find an unclaimed Machine for MachineDeployment %q: %w", machineDeployment.Name, err)
+// findMachineForNodeClaim resolves a CAPI Machine from a NodeClaim's providerID
+// or Machine annotation.
+func (c *CloudProvider) findMachineForNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*capiv1beta1.Machine, error) {
+	if len(nodeClaim.Status.ProviderID) != 0 {
+		m, err := c.machineProvider.GetByProviderID(ctx, nodeClaim.Status.ProviderID)
+		if err != nil {
+			return nil, fmt.Errorf("error finding Machine with provider ID %q to Delete NodeClaim %q: %w", nodeClaim.Status.ProviderID, nodeClaim.Name, err)
+		}
+		return m, nil
 	}
 
-	// now that we have a Machine for the NodeClaim, we label it as a karpenter member
-	labels := machine.GetLabels()
-	labels[providers.NodePoolMemberLabel] = ""
-	machine.SetLabels(labels)
-	if err := c.machineProvider.Update(ctx, machine); err != nil {
-		// if we can't update the Machine with the member label, we need to unwind the addition
-		// TODO (elmiko) add more logic here to fix the error, if we are in this state it's not clear how to fix,
-		// since we have a Machine, we should be reducing the replicas and annotating the Machine for deletion.
-		return nil, nil, fmt.Errorf("cannot satisfy create, unable to label Machine %q as a member: %w", machine.Name, err)
+	if machineAnno, ok := nodeClaim.Annotations[providers.MachineAnnotation]; ok {
+		machineNamespace, machineName, err := providers.ParseMachineAnnotation(machineAnno)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing machine annotation: %w", err)
+		}
+		m, err := c.machineProvider.Get(ctx, machineName, machineNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("error finding Machine %q in namespace %s to Delete NodeClaim %q: %w", machineName, machineNamespace, nodeClaim.Name, err)
+		}
+		return m, nil
 	}
 
-	// Bind the NodeClaim with this machine.
-	nodeClaim.Annotations[machineAnnotation] = fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
-	if err = c.kubeClient.Update(ctx, nodeClaim); err != nil {
-		return nil, nil, fmt.Errorf("cannot satisfy create, unable to update NodeClaim annotations %q: %w", nodeClaim.Name, err)
-	}
-
-	return machineDeployment, machine, nil
+	return nil, fmt.Errorf("NodeClaim %q does not have a provider ID or Machine annotations, cannot delete", nodeClaim.Name)
 }
 
 func (c *CloudProvider) machineDeploymentFromMachine(ctx context.Context, machine *capiv1beta1.Machine) (*capiv1beta1.MachineDeployment, error) {
@@ -461,45 +410,6 @@ func (c *CloudProvider) machineToNodeClaim(ctx context.Context, machine *capiv1b
 	nodeClaim.Status.Capacity = capacity
 
 	return &nodeClaim, nil
-}
-
-func (c *CloudProvider) pollForUnclaimedMachineInMachineDeploymentWithTimeout(ctx context.Context, machineDeployment *capiv1beta1.MachineDeployment, timeout time.Duration) (*capiv1beta1.Machine, error) {
-	var machine *capiv1beta1.Machine
-
-	// select all Machines that have the ownership label for the MachineDeployment, and do not have the
-	// label for karpenter node pool membership.
-	selector := &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{
-				Key:      providers.NodePoolMemberLabel,
-				Operator: metav1.LabelSelectorOpDoesNotExist,
-			},
-			{
-				Key:      capiv1beta1.MachineDeploymentNameLabel,
-				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{machineDeployment.Name},
-			},
-		},
-	}
-
-	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		machineList, err := c.machineProvider.List(ctx, machineDeployment.Namespace, selector)
-		if err != nil {
-			// this might need to ignore the error for the sake of the timeout
-			return false, fmt.Errorf("error listing unclaimed Machines for MachineDeployment %q: %w", machineDeployment.Name, err)
-		}
-		if len(machineList) == 0 {
-			return false, nil
-		}
-
-		machine = machineList[0]
-		return true, nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error polling for an unclaimed Machine in MachineDeployment %q: %w", machineDeployment.Name, err)
-	}
-
-	return machine, nil
 }
 
 func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*v1alpha1.ClusterAPINodeClass, error) {
@@ -752,21 +662,4 @@ func zoneLabelFromLabels(labels map[string]string) string {
 	}
 
 	return zone
-}
-
-func parseMachineAnnotation(annotationValue string) (string, string, error) {
-	parts := strings.Split(annotationValue, "/")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid machine annotations '%s'. Expected 'namespace/name'", annotationValue)
-	}
-
-	ns := strings.TrimSpace(parts[0])
-	name := strings.TrimSpace(parts[1])
-
-	// Additional validation for empty strings
-	if ns == "" || name == "" {
-		return "", "", fmt.Errorf("invalid machine format '%s'. Namespace and name cannot be empty", annotationValue)
-	}
-
-	return ns, name, nil
 }

--- a/pkg/providers/machine/machine.go
+++ b/pkg/providers/machine/machine.go
@@ -165,3 +165,4 @@ func (p *DefaultProvider) Update(ctx context.Context, machine *capiv1beta1.Machi
 
 	return nil
 }
+

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -16,7 +16,33 @@ limitations under the License.
 
 package providers
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	// NodePoolMemberLabel is a label used to identify resources that are used by karpenter
 	NodePoolMemberLabel = "node.cluster.x-k8s.io/karpenter-member"
+
+	// MachineAnnotation is the annotation on a NodeClaim that references
+	// the CAPI Machine bound to it, in "namespace/name" format.
+	MachineAnnotation = "cluster.x-k8s.io/machine"
 )
+
+// ParseMachineAnnotation splits a "namespace/name" annotation value into its components.
+func ParseMachineAnnotation(annotationValue string) (string, string, error) {
+	parts := strings.Split(annotationValue, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid machine annotation %q: expected 'namespace/name'", annotationValue)
+	}
+
+	ns := strings.TrimSpace(parts[0])
+	name := strings.TrimSpace(parts[1])
+
+	if ns == "" || name == "" {
+		return "", "", fmt.Errorf("invalid machine annotation %q: namespace and name cannot be empty", annotationValue)
+	}
+
+	return ns, name, nil
+}

--- a/pkg/providers/providers_test.go
+++ b/pkg/providers/providers_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"testing"
+)
+
+func TestParseMachineAnnotation(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantNS    string
+		wantName  string
+		wantError bool
+	}{
+		{
+			name:     "valid annotation",
+			input:    "default/my-machine",
+			wantNS:   "default",
+			wantName: "my-machine",
+		},
+		{
+			name:     "valid annotation with dashes",
+			input:    "kube-system/machine-abc-123",
+			wantNS:   "kube-system",
+			wantName: "machine-abc-123",
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantError: true,
+		},
+		{
+			name:      "no slash",
+			input:     "my-machine",
+			wantError: true,
+		},
+		{
+			name:      "too many slashes",
+			input:     "a/b/c",
+			wantError: true,
+		},
+		{
+			name:      "empty namespace",
+			input:     "/my-machine",
+			wantError: true,
+		},
+		{
+			name:      "empty name",
+			input:     "default/",
+			wantError: true,
+		},
+		{
+			name:      "only slash",
+			input:     "/",
+			wantError: true,
+		},
+		{
+			name:      "whitespace namespace",
+			input:     "  /my-machine",
+			wantError: true,
+		},
+		{
+			name:      "whitespace name",
+			input:     "default/  ",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, name, err := ParseMachineAnnotation(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error for input %q, got ns=%q name=%q", tt.input, ns, name)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for input %q: %v", tt.input, err)
+				return
+			}
+			if ns != tt.wantNS {
+				t.Errorf("namespace: got %q, want %q", ns, tt.wantNS)
+			}
+			if name != tt.wantName {
+				t.Errorf("name: got %q, want %q", name, tt.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #87 

**Description**
Replace the mutex-serialized Create/Delete with a time-windowed batching architecture. Concurrent requests targeting the same MachineDeployment are coalesced into a single replica read-modify-write cycle, reducing optimistic concurrency conflicts that caused replica leaks and reducing lock scope from the entire create/poll flow to just the replica update.

Create batches count unclaimed Machines and increment replicas only by the deficit, so retries never over-provision. Delete batches annotate Machines in parallel and decrement replicas in one write with rollback of the annotations on failure (we don't rollback replica changes).

This PR adds:
- `pkg/batcher/` — generic `Batcher[T, U]` (adapted from karpenter-provider-aws), plus CAPI-specific `CreateBatcher` and `DeleteBatcher`
- `MDLockManager` — per-MachineDeployment mutex that serializes replica updates between create and delete batches
- `providers.MachineAnnotation` + `ParseMachineAnnotation` — moved the machine annotation constant out of cloudprovider into a shared location
- unit tests testing core functionality and corner cases of the each batcher individually as well as the create + delete batching interactions together

Other notes:
- The create executor's "count unclaimed first" strategy means there is no explicit replica rollback on partial failure — retries from the lifecycle controller will see the existing unclaimed Machines and not increment again. The algorithm is documented on `execCreateBatch`.
- `bindMachineToNodeClaim` retries the Machine label Update up to 3 times in the case of optimistic concurrency failures (stale resourceVersion).
- The poll step (`pollForNUnclaimedMachines`) runs unlocked with a 30s timeout. A concurrent delete batch can cause the poll to find fewer Machines than expected, but unfulfilled requests will simply error out and retry naturally.

Assisted with Cursor agent with Claude 4.6 opus model.

**How was this change tested?**

Regressions performance E2E tests and new batcher unit tests included in this PR. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
