### PR TITLE
ci: point cloudbuild.yaml to correct staging registry and repo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
 - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest'
   entrypoint: make
   env:
-    - IMG_REPO=gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller
+    - IMG_REPO=us-central1-docker.pkg.dev/k8s-staging-images/karpenter-cluster-api
     - IMG_TAG=$_GIT_TAG
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint


### PR DESCRIPTION
Fixes #N/A

**Description**
Automated image push build is failing cause the cloudbuild.yaml is point to the wrong staging registry and repository. See https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-karpenter-provider-cluster-api-push-images/2067302053893378048

This PR fixes that according to: https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io and https://github.com/kubernetes/k8s.io/blob/5820c36e7c9f6de823461947ca3c917191708a5e/infra/gcp/terraform/k8s-staging-images/registries.tf#L42. This is the last step in enabling automatic staging image builds. See https://github.com/kubernetes-sigs/dra-example-driver/pull/77/changes for a similar `cloudbuild.yaml` file with the same registry, but different repo.

Note that these images will be deleted after 90 days, so no one should rely on them. 

Next step after this is to enable promotion of one of our staging images after we do our next release: https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io#image-promoter

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
