### PR TITLE
ci: fixup cloudbuild.yaml again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ BUILDER_IMAGE ?=
 BUILDX_CMD ?= $(CONTAINER_RUNTIME) buildx
 IMG_BUILD_CMD ?= $(BUILDX_CMD) build
 
-IMG_REGISTRY ?= gcr.io/k8s-staging-karpenter-cluster-api
-IMG_NAME ?= karpenter-clusterapi-controller
+IMG_REGISTRY ?= us-central1-docker.pkg.dev/k8s-staging-images/karpenter-cluster-api
+IMG_NAME ?= controller
 IMG_REPO ?= $(IMG_REGISTRY)/$(IMG_NAME)
 IMG_TAG ?= $(shell git describe --tags --dirty --always)
 IMG ?= $(IMG_REPO):$(IMG_TAG)

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   # -- Repo to use for the image
-  repo: gcr.io/k8s-staging-karpenter-cluster-api/karpenter-clusterapi-controller
+  repo: us-central1-docker.pkg.dev/k8s-staging-images/karpenter-cluster-api/controller
   # -- Tag of the controller image
   tag: latest
   # -- Image pull policy of the controller image

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
 - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest'
   entrypoint: make
   env:
-    - IMG_REPO=us-central1-docker.pkg.dev/k8s-staging-images/karpenter-cluster-api
+    - IMG_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/karpenter-cluster-api
     - IMG_TAG=$_GIT_TAG
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint


### PR DESCRIPTION
CI is failing cause of
ERROR: failed to build: name invalid: Missing image name. Pushes should be of the form docker push HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE Changes cloudbuild to reference IMG_REGISTRY instead. The image name will now be "controller".

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
